### PR TITLE
feat: 기업회원(구인자) 로그인

### DIFF
--- a/src/main/java/team9502/sinchulgwinong/domain/auth/controller/AuthController.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/auth/controller/AuthController.java
@@ -13,9 +13,11 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import team9502.sinchulgwinong.domain.auth.dto.request.CompanyUserLoginRequestDTO;
 import team9502.sinchulgwinong.domain.auth.dto.request.CpUserSignupRequestDTO;
 import team9502.sinchulgwinong.domain.auth.dto.request.UserLoginRequestDTO;
 import team9502.sinchulgwinong.domain.auth.dto.request.UserSignupRequestDTO;
+import team9502.sinchulgwinong.domain.auth.dto.response.CompanyUserLoginResponseDTO;
 import team9502.sinchulgwinong.domain.auth.dto.response.UserLoginResponseDTO;
 import team9502.sinchulgwinong.domain.auth.service.AuthService;
 import team9502.sinchulgwinong.global.response.GlobalApiResponse;
@@ -105,6 +107,33 @@ public class AuthController {
                 .body(
                         GlobalApiResponse.of(
                                 SUCCESS_USER_LOGIN.getMessage(),
+                                responseDTO
+                        )
+                );
+    }
+
+    @PostMapping("/cp-login")
+    @Operation(summary = "기업 회원 로그인", description = "기업 회원이 로그인합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그인 성공",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = "{ \"code\": \"200\", \"message\": \"로그인 성공\", \"data\": null }"))),
+            @ApiResponse(responseCode = "400", description = "로그인 실패",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = "{ \"code\": \"400\", \"message\": \"로그인 실패\", \"data\": null }"))),
+            @ApiResponse(responseCode = "500", description = "서버 에러",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = "{ \"code\": \"500\", \"message\": \"서버 에러\", \"data\": null }")))
+    })
+    public ResponseEntity<GlobalApiResponse<CompanyUserLoginResponseDTO>> cpLogin(
+            @RequestBody @Valid CompanyUserLoginRequestDTO requestDTO) {
+
+        CompanyUserLoginResponseDTO responseDTO = authService.cpLogin(requestDTO);
+
+        return ResponseEntity.status(SUCCESS_CP_USER_LOGIN.getHttpStatus())
+                .body(
+                        GlobalApiResponse.of(
+                                SUCCESS_CP_USER_LOGIN.getMessage(),
                                 responseDTO
                         )
                 );

--- a/src/main/java/team9502/sinchulgwinong/domain/auth/controller/AuthController.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/auth/controller/AuthController.java
@@ -14,12 +14,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import team9502.sinchulgwinong.domain.auth.dto.request.CpUserSignupRequestDTO;
+import team9502.sinchulgwinong.domain.auth.dto.request.UserLoginRequestDTO;
 import team9502.sinchulgwinong.domain.auth.dto.request.UserSignupRequestDTO;
+import team9502.sinchulgwinong.domain.auth.dto.response.UserLoginResponseDTO;
 import team9502.sinchulgwinong.domain.auth.service.AuthService;
 import team9502.sinchulgwinong.global.response.GlobalApiResponse;
 
-import static team9502.sinchulgwinong.global.response.SuccessCode.SUCCESS_CP_USER_SIGN_UP;
-import static team9502.sinchulgwinong.global.response.SuccessCode.SUCCESS_USER_SIGN_UP;
+import static team9502.sinchulgwinong.global.response.SuccessCode.*;
 
 @RestController
 @RequestMapping("/auth")
@@ -78,6 +79,33 @@ public class AuthController {
                 .body(
                         GlobalApiResponse.of(SUCCESS_CP_USER_SIGN_UP.getMessage(),
                                 null
+                        )
+                );
+    }
+
+    @PostMapping("/login")
+    @Operation(summary = "구직자 로그인", description = "사용자가 이메일로 로그인합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그인 성공",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = "{ \"code\": \"200\", \"message\": \"로그인 성공\", \"data\": null }"))),
+            @ApiResponse(responseCode = "400", description = "로그인 실패",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = "{ \"code\": \"400\", \"message\": \"로그인 실패\", \"data\": null }"))),
+            @ApiResponse(responseCode = "500", description = "서버 에러",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = "{ \"code\": \"500\", \"message\": \"서버 에러\", \"data\": null }")))
+    })
+    public ResponseEntity<GlobalApiResponse<UserLoginResponseDTO>> login(
+            @RequestBody @Valid UserLoginRequestDTO requestDTO) {
+
+        UserLoginResponseDTO responseDTO = authService.login(requestDTO);
+
+        return ResponseEntity.status(SUCCESS_USER_LOGIN.getHttpStatus())
+                .body(
+                        GlobalApiResponse.of(
+                                SUCCESS_USER_LOGIN.getMessage(),
+                                responseDTO
                         )
                 );
     }

--- a/src/main/java/team9502/sinchulgwinong/domain/auth/dto/request/CompanyUserLoginRequestDTO.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/auth/dto/request/CompanyUserLoginRequestDTO.java
@@ -1,0 +1,24 @@
+package team9502.sinchulgwinong.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CompanyUserLoginRequestDTO {
+
+    @NotBlank(message = "필수 입력입니다.")
+    private String cpEmail;
+
+    @NotBlank(message = "필수 입력입니다.")
+    private String cpPassword;
+
+    @Builder
+    public CompanyUserLoginRequestDTO(String cpEmail, String cpPassword) {
+        this.cpEmail = cpEmail;
+        this.cpPassword = cpPassword;
+    }
+}

--- a/src/main/java/team9502/sinchulgwinong/domain/auth/dto/response/CompanyUserLoginResponseDTO.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/auth/dto/response/CompanyUserLoginResponseDTO.java
@@ -1,0 +1,25 @@
+package team9502.sinchulgwinong.domain.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CompanyUserLoginResponseDTO {
+
+    private Long cpUserId;
+
+    private String cpUsername;
+
+    private String cpName;
+
+    private String cpEmail;
+
+    private String cpPhoneNumber;
+
+    private Boolean hiringStatus;
+
+    private Integer employeeCount;
+}

--- a/src/main/java/team9502/sinchulgwinong/domain/auth/service/AuthService.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/auth/service/AuthService.java
@@ -8,9 +8,11 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import team9502.sinchulgwinong.domain.auth.dto.request.CompanyUserLoginRequestDTO;
 import team9502.sinchulgwinong.domain.auth.dto.request.CpUserSignupRequestDTO;
 import team9502.sinchulgwinong.domain.auth.dto.request.UserLoginRequestDTO;
 import team9502.sinchulgwinong.domain.auth.dto.request.UserSignupRequestDTO;
+import team9502.sinchulgwinong.domain.auth.dto.response.CompanyUserLoginResponseDTO;
 import team9502.sinchulgwinong.domain.auth.dto.response.UserLoginResponseDTO;
 import team9502.sinchulgwinong.domain.companyUser.entity.CompanyUser;
 import team9502.sinchulgwinong.domain.companyUser.repository.CompanyUserRepository;
@@ -37,11 +39,10 @@ public class AuthService {
 
     public void signup(UserSignupRequestDTO signupRequest) {
 
-        validateSignupRequest(signupRequest.getEmail(), signupRequest.getPassword(),
+        validateUserSignupRequest(signupRequest.getEmail(), signupRequest.getPassword(),
                 signupRequest.getConfirmPassword(), signupRequest.isAgreeToTerms());
 
         try {
-
             User user = User.builder()
                     .username(signupRequest.getUsername())
                     .nickname(signupRequest.getNickname())
@@ -59,11 +60,10 @@ public class AuthService {
 
     public void cpSignup(CpUserSignupRequestDTO requestDTO) {
 
-        validateSignupRequest(requestDTO.getCpEmail(), requestDTO.getCpPassword(),
+        validateCpSignupRequest(requestDTO.getCpEmail(), requestDTO.getCpPassword(),
                 requestDTO.getCpConfirmPassword(), requestDTO.isAgreeToTerms());
 
         try {
-
             String encryptedCpNum = encryptionService.encryptCpNum(requestDTO.getCpNum());
 
             CompanyUser companyUser = CompanyUser.builder()
@@ -115,20 +115,63 @@ public class AuthService {
         );
     }
 
+    public CompanyUserLoginResponseDTO cpLogin(CompanyUserLoginRequestDTO loginRequest) {
+
+        Authentication authentication = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(
+                        loginRequest.getCpEmail(), loginRequest.getCpPassword()
+                )
+        );
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        String jwt = jwtTokenProvider.generateToken(authentication);
+
+        Optional<CompanyUser> companyUserOptional = companyUserRepository.findByCpEmail(loginRequest.getCpEmail());
+        if (companyUserOptional.isEmpty()) {
+            throw new ApiException(ErrorCode.USER_NOT_FOUND);
+        }
+
+        CompanyUser companyUser = companyUserOptional.get();
+
+        return new CompanyUserLoginResponseDTO(
+                companyUser.getCpUserId(),
+                companyUser.getCpUsername(),
+                companyUser.getCpName(),
+                companyUser.getCpEmail(),
+                companyUser.getCpPhoneNumber(),
+                companyUser.getHiringStatus(),
+                companyUser.getEmployeeCount()
+        );
+    }
+
     /*
         중복된 예외처리의 메서드 추출
      */
 
-    private void validateSignupRequest(String email, String password, String confirmPassword, boolean agreeToTerms) {
+    private void validateUserSignupRequest(String email, String password, String confirmPassword, boolean agreeToTerms) {
         if (!agreeToTerms) {
             throw new ApiException(ErrorCode.TERMS_NOT_ACCEPTED);
         }
 
-        if (userRepository.findByEmail(email).isPresent() || companyUserRepository.findByCpEmail(email).isPresent()) {
+        if (userRepository.findByEmail(email).isPresent()) {
             throw new ApiException(ErrorCode.EMAIL_DUPLICATION);
         }
 
         if (!password.equals(confirmPassword)) {
+            throw new ApiException(ErrorCode.PASSWORD_MISMATCH);
+        }
+    }
+
+    private void validateCpSignupRequest(String cpEmail, String cpPassword, String cpConfirmPassword, boolean agreeToTerms) {
+        if (!agreeToTerms) {
+            throw new ApiException(ErrorCode.TERMS_NOT_ACCEPTED);
+        }
+
+        if (companyUserRepository.findByCpEmail(cpEmail).isPresent()) {
+            throw new ApiException(ErrorCode.EMAIL_DUPLICATION);
+        }
+
+        if (!cpPassword.equals(cpConfirmPassword)) {
             throw new ApiException(ErrorCode.PASSWORD_MISMATCH);
         }
     }

--- a/src/main/java/team9502/sinchulgwinong/global/config/WebSecurityConfig.java
+++ b/src/main/java/team9502/sinchulgwinong/global/config/WebSecurityConfig.java
@@ -23,7 +23,7 @@ public class WebSecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/", "/home", "/swagger-ui.html", "/v3/api-docs/**", "/swagger-ui/**").permitAll()
-                        .requestMatchers("/auth/signup", "auth/login", "/auth/cp-signup").permitAll()
+                        .requestMatchers("/auth/signup", "auth/login", "/auth/cp-signup", "/auth/cp-login").permitAll()
                         .requestMatchers("/business/status", "business/verify").permitAll()
                         .anyRequest().authenticated())
                 .formLogin(AbstractAuthenticationFilterConfigurer::disable)

--- a/src/main/java/team9502/sinchulgwinong/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/team9502/sinchulgwinong/global/jwt/JwtAuthenticationFilter.java
@@ -15,8 +15,12 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.stereotype.Component;
+import team9502.sinchulgwinong.domain.auth.dto.request.CompanyUserLoginRequestDTO;
 import team9502.sinchulgwinong.domain.auth.dto.request.UserLoginRequestDTO;
+import team9502.sinchulgwinong.domain.auth.dto.response.CompanyUserLoginResponseDTO;
 import team9502.sinchulgwinong.domain.auth.dto.response.UserLoginResponseDTO;
+import team9502.sinchulgwinong.domain.companyUser.entity.CompanyUser;
+import team9502.sinchulgwinong.domain.companyUser.repository.CompanyUserRepository;
 import team9502.sinchulgwinong.domain.user.entity.User;
 import team9502.sinchulgwinong.domain.user.repository.UserRepository;
 import team9502.sinchulgwinong.global.exception.ApiException;
@@ -33,23 +37,34 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
     private final JwtTokenProvider tokenProvider;
     private final ObjectMapper objectMapper;
     private final UserRepository userRepository;
+    private final CompanyUserRepository companyUserRepository;
 
     @Autowired
-    public JwtAuthenticationFilter(AuthenticationManager authenticationManager, JwtTokenProvider tokenProvider, UserRepository userRepository) {
+    public JwtAuthenticationFilter(AuthenticationManager authenticationManager, JwtTokenProvider tokenProvider,
+                                   UserRepository userRepository, CompanyUserRepository companyUserRepository) {
         super.setAuthenticationManager(authenticationManager);
         this.tokenProvider = tokenProvider;
         this.objectMapper = new ObjectMapper();
         this.userRepository = userRepository;
+        this.companyUserRepository = companyUserRepository;
         setFilterProcessesUrl("/auth/login");
+        setFilterProcessesUrl("/auth/cp-login");
     }
 
     @Override
     public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
         try {
-            UserLoginRequestDTO loginRequest = objectMapper.readValue(request.getInputStream(), UserLoginRequestDTO.class);
-            UsernamePasswordAuthenticationToken authRequest = new UsernamePasswordAuthenticationToken(
-                    loginRequest.getEmail(), loginRequest.getPassword());
-            return getAuthenticationManager().authenticate(authRequest);
+            if (request.getRequestURI().contains("/cp-login")) {
+                CompanyUserLoginRequestDTO loginRequest = objectMapper.readValue(request.getInputStream(), CompanyUserLoginRequestDTO.class);
+                UsernamePasswordAuthenticationToken authRequest = new UsernamePasswordAuthenticationToken(
+                        loginRequest.getCpEmail(), loginRequest.getCpPassword());
+                return getAuthenticationManager().authenticate(authRequest);
+            } else {
+                UserLoginRequestDTO loginRequest = objectMapper.readValue(request.getInputStream(), UserLoginRequestDTO.class);
+                UsernamePasswordAuthenticationToken authRequest = new UsernamePasswordAuthenticationToken(
+                        loginRequest.getEmail(), loginRequest.getPassword());
+                return getAuthenticationManager().authenticate(authRequest);
+            }
         } catch (IOException e) {
             throw new ApiException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
@@ -65,24 +80,45 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
 
         UserDetails userDetails = (UserDetails) authResult.getPrincipal();
-        User user = userRepository.findByEmail(userDetails.getUsername())
-                .orElseThrow(() -> new ApiException(ErrorCode.USER_NOT_FOUND));
 
-        UserLoginResponseDTO userLoginResponseDTO = new UserLoginResponseDTO(
-                user.getUserId(),
-                user.getUsername(),
-                user.getNickname(),
-                user.getEmail(),
-                user.getPhoneNumber(),
-                user.getLoginType()
-        );
+        if (request.getRequestURI().contains("/cp-login")) {
+            CompanyUser cpUser = companyUserRepository.findByCpEmail(userDetails.getUsername())
+                    .orElseThrow(() -> new ApiException(ErrorCode.USER_NOT_FOUND));
 
-        GlobalApiResponse<UserLoginResponseDTO> globalApiResponse = GlobalApiResponse.of(SuccessCode.OK.getMessage(), userLoginResponseDTO);
-        response.getWriter().write(objectMapper.writeValueAsString(globalApiResponse));
+            CompanyUserLoginResponseDTO companyUserLoginResponseDTO = new CompanyUserLoginResponseDTO(
+                    cpUser.getCpUserId(),
+                    cpUser.getCpUsername(),
+                    cpUser.getCpName(),
+                    cpUser.getCpEmail(),
+                    cpUser.getCpPhoneNumber(),
+                    cpUser.getHiringStatus(),
+                    cpUser.getEmployeeCount()
+            );
+
+            GlobalApiResponse<CompanyUserLoginResponseDTO> globalApiResponse = GlobalApiResponse.of(SuccessCode.OK.getMessage(), companyUserLoginResponseDTO);
+            response.getWriter().write(objectMapper.writeValueAsString(globalApiResponse));
+
+        } else {
+            User user = userRepository.findByEmail(userDetails.getUsername())
+                    .orElseThrow(() -> new ApiException(ErrorCode.USER_NOT_FOUND));
+
+            UserLoginResponseDTO userLoginResponseDTO = new UserLoginResponseDTO(
+                    user.getUserId(),
+                    user.getUsername(),
+                    user.getNickname(),
+                    user.getEmail(),
+                    user.getPhoneNumber(),
+                    user.getLoginType()
+            );
+
+            GlobalApiResponse<UserLoginResponseDTO> globalApiResponse = GlobalApiResponse.of(SuccessCode.OK.getMessage(), userLoginResponseDTO);
+            response.getWriter().write(objectMapper.writeValueAsString(globalApiResponse));
+        }
     }
 
     @Override
-    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws IOException, ServletException {
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse
+            response, AuthenticationException failed) throws IOException, ServletException {
         response.setStatus(HttpStatus.UNAUTHORIZED.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());

--- a/src/main/java/team9502/sinchulgwinong/global/response/SuccessCode.java
+++ b/src/main/java/team9502/sinchulgwinong/global/response/SuccessCode.java
@@ -12,6 +12,7 @@ public enum SuccessCode {
     SUCCESS_USER_SIGN_UP(HttpStatus.CREATED, "구직자 회원 가입 성공"),
     SUCCESS_CP_USER_SIGN_UP(HttpStatus.CREATED, "기업 회원 가입 성공"),
     SUCCESS_USER_LOGIN(HttpStatus.OK, "구직자 로그인 성공"),
+    SUCCESS_CP_USER_LOGIN(HttpStatus.OK, "기업 회원 로그인 성공"),
 
     // Global
     OK(HttpStatus.OK, "요청 성공");

--- a/src/main/java/team9502/sinchulgwinong/global/response/SuccessCode.java
+++ b/src/main/java/team9502/sinchulgwinong/global/response/SuccessCode.java
@@ -10,7 +10,8 @@ public enum SuccessCode {
 
     // Auth
     SUCCESS_USER_SIGN_UP(HttpStatus.CREATED, "구직자 회원 가입 성공"),
-    SUCCESS_CP_USER_SIGN_UP(HttpStatus.CREATED, "구인자 회원 가입 성공"),
+    SUCCESS_CP_USER_SIGN_UP(HttpStatus.CREATED, "기업 회원 가입 성공"),
+    SUCCESS_USER_LOGIN(HttpStatus.OK, "구직자 로그인 성공"),
 
     // Global
     OK(HttpStatus.OK, "요청 성공");

--- a/src/main/java/team9502/sinchulgwinong/global/security/UserDetailsImpl.java
+++ b/src/main/java/team9502/sinchulgwinong/global/security/UserDetailsImpl.java
@@ -10,11 +10,13 @@ public class UserDetailsImpl implements UserDetails {
     private final String email;
     private final String password;
     private final Collection<? extends GrantedAuthority> authorities;
+    private final String userType;
 
-    public UserDetailsImpl(String email, String password, Collection<? extends GrantedAuthority> authorities) {
+    public UserDetailsImpl(String email, String password, Collection<? extends GrantedAuthority> authorities, String userType) {
         this.email = email;
         this.password = password;
         this.authorities = authorities;
+        this.userType = userType;
     }
 
     @Override
@@ -30,6 +32,10 @@ public class UserDetailsImpl implements UserDetails {
     @Override
     public String getUsername() {
         return email;
+    }
+
+    public String getUserType() {
+        return userType;
     }
 
     @Override

--- a/src/main/java/team9502/sinchulgwinong/global/security/UserDetailsServiceImpl.java
+++ b/src/main/java/team9502/sinchulgwinong/global/security/UserDetailsServiceImpl.java
@@ -1,9 +1,12 @@
 package team9502.sinchulgwinong.global.security;
 
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+import team9502.sinchulgwinong.domain.companyUser.entity.CompanyUser;
+import team9502.sinchulgwinong.domain.companyUser.repository.CompanyUserRepository;
 import team9502.sinchulgwinong.domain.user.entity.User;
 import team9502.sinchulgwinong.domain.user.repository.UserRepository;
 
@@ -13,16 +16,24 @@ import java.util.Collections;
 public class UserDetailsServiceImpl implements UserDetailsService {
 
     private final UserRepository userRepository;
+    private final CompanyUserRepository companyUserRepository;
 
-    public UserDetailsServiceImpl(UserRepository userRepository) {
+    public UserDetailsServiceImpl(UserRepository userRepository, CompanyUserRepository companyUserRepository) {
         this.userRepository = userRepository;
+        this.companyUserRepository = companyUserRepository;
     }
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new UsernameNotFoundException(email + "으로 등록된 사용자를 찾을 수 없습니다."));
+        User user = userRepository.findByEmail(email).orElse(null);
+        if (user != null) {
+            return new UserDetailsImpl(user.getEmail(), user.getPassword(),
+                    Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")), "USER");
+        }
 
-        return new UserDetailsImpl(user.getEmail(), user.getPassword(), Collections.emptyList());
+        CompanyUser companyUser = companyUserRepository.findByCpEmail(email).orElseThrow(() ->
+                new UsernameNotFoundException(email + "으로 등록된 사용자를 찾을 수 없습니다."));
+        return new UserDetailsImpl(companyUser.getCpEmail(), companyUser.getCpPassword(),
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_COMPANY")), "COMPANY");
     }
 }


### PR DESCRIPTION
이번 PR에서는 기업회원 로그인을 위한 기능을 추가하였습니다. 이를 통해 기업회원이 일반 사용자와 구분되어 로그인하고, 적절한 권한을 부여받을 수 있습니다.

#### 주요 변경 사항
1. **`UserDetailsImpl` 수정**: 
   - 사용자 타입(`userType`) 필드를 추가하여 일반 사용자와 기업 사용자를 구분할 수 있도록 수정하였습니다.
   - 이에 따른 생성자와 getter 메서드를 추가하였습니다.

2. **`UserDetailsServiceImpl` 수정**:
   - `UserRepository`와 `CompanyUserRepository`를 이용하여 일반 사용자와 기업 사용자를 각각 조회하고 처리하도록 수정하였습니다.
   - 일반 사용자에게는 `ROLE_USER` 권한을, 기업 사용자에게는 `ROLE_COMPANY` 권한을 부여하도록 하였습니다.

3. **`WebSecurityConfig` 수정**:
   - 각 역할에 따라 접근 권한을 설정하였습니다.
   - `/business/status` 및 `/business/verify` 엔드포인트에 대해서는 `ROLE_COMPANY` 권한이 필요한 것으로 설정하였습니다.
   - 그 외의 엔드포인트는 인증된 사용자만 접근할 수 있도록 설정하였습니다.

#### 변경된 파일 목록
- `WebSecurityConfig.java`
- `UserDetailsImpl.java`
- `UserDetailsServiceImpl.java`

#### 테스트 내용
- 일반 사용자와 기업 사용자가 각각의 로그인 엔드포인트에서 성공적으로 로그인할 수 있는지 확인하였습니다.
- 권한에 따라 접근이 제한되는 엔드포인트에 대해 올바른 권한이 부여된 경우에만 접근이 가능한지 테스트하였습니다.

#### 기타 참고 사항
- 이 PR은 기업회원과 일반 사용자의 역할 구분을 명확히 하여 보안성을 강화하는 데 중점을 두었습니다.
- 기존의 일반 사용자 로그인 기능은 영향을 받지 않도록 설계하였습니다.

검토 부탁드립니다. 감사합니다.