### PR TITLE
Feature/point 포인트 설정

### DIFF
--- a/src/main/java/team9502/sinchulgwinong/domain/point/entity/Point.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/point/entity/Point.java
@@ -1,0 +1,23 @@
+package team9502.sinchulgwinong.domain.point.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "Points")
+public class Point {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long pointId;
+
+    @Column(nullable = false)
+    private Integer point;
+}

--- a/src/main/java/team9502/sinchulgwinong/domain/point/entity/SavedPoint.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/point/entity/SavedPoint.java
@@ -1,0 +1,36 @@
+package team9502.sinchulgwinong.domain.point.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import team9502.sinchulgwinong.domain.point.enums.SpType;
+import team9502.sinchulgwinong.global.entity.BaseTimeEntity;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "SavedPoints")
+public class SavedPoint extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long spId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pointId", nullable = false)
+    private Point point;
+
+    @Column(nullable = false)
+    private Integer spAmount;
+
+    @Column(nullable = false)
+    private Integer spBalance;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private SpType spType;
+}

--- a/src/main/java/team9502/sinchulgwinong/domain/point/entity/UsedPoint.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/point/entity/UsedPoint.java
@@ -1,0 +1,36 @@
+package team9502.sinchulgwinong.domain.point.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import team9502.sinchulgwinong.domain.point.enums.UpType;
+import team9502.sinchulgwinong.global.entity.BaseTimeEntity;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "UsedPoints")
+public class UsedPoint extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long upId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pointId", nullable = false)
+    private Point point;
+
+    @Column(nullable = false)
+    private Integer upAmount;
+
+    @Column(nullable = false)
+    private Integer upBalance;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UpType upType;
+}

--- a/src/main/java/team9502/sinchulgwinong/domain/point/enums/SpType.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/point/enums/SpType.java
@@ -1,0 +1,6 @@
+package team9502.sinchulgwinong.domain.point.enums;
+
+public enum SpType {
+
+    REVIEW, SIGNUP, BOARD, EVENT
+}

--- a/src/main/java/team9502/sinchulgwinong/domain/point/enums/UpType.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/point/enums/UpType.java
@@ -1,0 +1,6 @@
+package team9502.sinchulgwinong.domain.point.enums;
+
+public enum UpType {
+
+    REVIEW, BANNER, PROFILE
+}


### PR DESCRIPTION
#### 변경 사항
- `Point` 엔티티 클래스 추가.
- `SavedPoint` 엔티티에 `Point` 엔티티의 참조를 추가하여 일대다 관계 설정.
- `UsedPoint` 엔티티에 `Point` 엔티티의 참조를 추가하여 일대다 관계 설정.
- `SavedPoint`의 `spType` ENUM에 대한 설명을 개선하고, 데이터베이스 스키마와 일치시킴.
- `UsedPoint`의 `upType` ENUM에 대한 설명을 개선하고, 데이터베이스 스키마와 일치시킴.

#### 이유
시스템의 포인트 관리 기능을 강화하고 사용자의 포인트 적립 및 사용 내역을 보다 효율적으로 관리하기 위해 `Point` 엔티티와 `SavedPoint`의 관계와 `Point` 엔티티와 `UsedPoint`의 관계를 명확히 정의했습니다. 
이는 포인트 적립 및 사용의 추적을 개선하고, 데이터 무결성을 유지하는 데 도움이 됩니다.

#### 테스트
- `Point`와 `SavedPoint` 엔티티의 생성 및 관계 매핑이 올바르게 작동하는지 확인.
- 로컬 환경에서 데이터베이스와의 상호 작용을 테스트하고, 적립 및 사용 로그가 정확하게 기록되는지 검증.