### PR TITLE
feat: 포인트 적립 내역 조회

### DIFF
--- a/src/main/java/team9502/sinchulgwinong/domain/point/controller/PointController.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/point/controller/PointController.java
@@ -13,11 +13,15 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import team9502.sinchulgwinong.domain.point.dto.response.PointSummaryResponseDTO;
+import team9502.sinchulgwinong.domain.point.dto.response.SavedPointDetailResponseDTO;
 import team9502.sinchulgwinong.domain.point.service.PointService;
 import team9502.sinchulgwinong.global.response.GlobalApiResponse;
 import team9502.sinchulgwinong.global.security.UserDetailsImpl;
 
+import java.util.List;
+
 import static team9502.sinchulgwinong.global.response.SuccessCode.SUCCESS_POINT_SUMMARY_READ;
+import static team9502.sinchulgwinong.global.response.SuccessCode.SUCCESS_SAVED_POINT_READ;
 
 @RestController
 @RequiredArgsConstructor
@@ -28,9 +32,9 @@ public class PointController {
     private final PointService pointService;
 
     @GetMapping
-    @Operation(summary = "사용자 포인트 조회", description = "사용자의 적립 및 사용 포인트 총액을 조회합니다.")
+    @Operation(summary = "포인트 총액 조회", description = "로그인한 사용자의 적립 및 사용 포인트 총액을 조회합니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "포인트 조회 성공",
+            @ApiResponse(responseCode = "200", description = "포인트 총액 조회 성공",
                     content = @Content(mediaType = "application/json",
                             examples = @ExampleObject(value = "{ \"code\": \"200\", \"message\": \"포인트 조회 성공\", \"data\": {\"totalSaved\": 500, \"totalUsed\": 300} }"))),
             @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음",
@@ -50,6 +54,33 @@ public class PointController {
                         GlobalApiResponse.of(
                                 SUCCESS_POINT_SUMMARY_READ.getMessage(),
                                 responseDTO
+                        )
+                );
+    }
+
+    @GetMapping("/details")
+    @Operation(summary = "포인트 적립 내역 조회", description = "로그인한 사용자의 포인트 적립 내역을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "포인트 적립 내역 조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = "{ \"code\": \"200\", \"message\": \"포인트 세부 조회 성공\", \"data\": [{\"type\": \"REVIEW\", \"savedPoint\": 100, \"createdAt\": \"2021-07-01\"}] }"))),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = "{ \"code\": \"404\", \"message\": \"사용자를 찾을 수 없습니다.\", \"data\": null }"))),
+            @ApiResponse(responseCode = "500", description = "서버 에러",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = "{ \"code\": \"500\", \"message\": \"서버 에러\", \"data\": null }")))
+    })
+    public ResponseEntity<GlobalApiResponse<List<SavedPointDetailResponseDTO>>> getPointDetails(
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        List<SavedPointDetailResponseDTO> responseDTOs = pointService.getSpDetails(userDetails);
+
+        return ResponseEntity.status(SUCCESS_SAVED_POINT_READ.getHttpStatus())
+                .body(
+                        GlobalApiResponse.of(
+                                SUCCESS_SAVED_POINT_READ.getMessage(),
+                                responseDTOs
                         )
                 );
     }

--- a/src/main/java/team9502/sinchulgwinong/domain/point/controller/PointController.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/point/controller/PointController.java
@@ -11,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import team9502.sinchulgwinong.domain.point.dto.response.PointSummaryResponseDTO;
 import team9502.sinchulgwinong.domain.point.dto.response.SavedPointDetailResponseDTO;
@@ -59,7 +60,7 @@ public class PointController {
     }
 
     @GetMapping("/details")
-    @Operation(summary = "포인트 적립 내역 조회", description = "로그인한 사용자의 포인트 적립 내역을 조회합니다.")
+    @Operation(summary = "포인트 적립 내역 조회", description = "로그인한 사용자의 포인트 적립 내역을 커서 기반 페이지네이션으로 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "포인트 적립 내역 조회 성공",
                     content = @Content(mediaType = "application/json",
@@ -72,9 +73,15 @@ public class PointController {
                             examples = @ExampleObject(value = "{ \"code\": \"500\", \"message\": \"서버 에러\", \"data\": null }")))
     })
     public ResponseEntity<GlobalApiResponse<List<SavedPointDetailResponseDTO>>> getPointDetails(
-            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestParam(value = "cursorId", required = false) Long cursorId,
+            @RequestParam(value = "limit", defaultValue = "6") int limit) {
 
-        List<SavedPointDetailResponseDTO> responseDTOs = pointService.getSpDetails(userDetails);
+        if (cursorId == null) {
+            cursorId = Long.MAX_VALUE;
+        }
+
+        List<SavedPointDetailResponseDTO> responseDTOs = pointService.getSpDetails(userDetails, cursorId, limit);
 
         return ResponseEntity.status(SUCCESS_SAVED_POINT_READ.getHttpStatus())
                 .body(

--- a/src/main/java/team9502/sinchulgwinong/domain/point/controller/PointController.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/point/controller/PointController.java
@@ -26,7 +26,7 @@ import static team9502.sinchulgwinong.global.response.SuccessCode.SUCCESS_SAVED_
 
 @RestController
 @RequiredArgsConstructor
-@Tag(name = "Point", description = "포인트 관련 API")
+@Tag(name = "Point", description = "포인트 관련 API [김은채]")
 @RequestMapping("/points")
 public class PointController {
 
@@ -64,10 +64,10 @@ public class PointController {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "포인트 적립 내역 조회 성공",
                     content = @Content(mediaType = "application/json",
-                            examples = @ExampleObject(value = "{ \"code\": \"200\", \"message\": \"포인트 세부 조회 성공\", \"data\": [{\"type\": \"REVIEW\", \"savedPoint\": 100, \"createdAt\": \"2021-07-01\"}] }"))),
-            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음",
+                            examples = @ExampleObject(value = "{ \"code\": \"200\", \"message\": \"적립 포인트 조회 성공\", \"data\": [{\"type\": \"REVIEW\", \"savedPoint\": 300, \"createdAt\": \"2024-06-11\"}, {\"type\": \"SIGNUP\", \"savedPoint\": 300, \"createdAt\": \"2024-06-11\"}] }"))),
+            @ApiResponse(responseCode = "404", description = "포인트를 찾을 수 없습니다.",
                     content = @Content(mediaType = "application/json",
-                            examples = @ExampleObject(value = "{ \"code\": \"404\", \"message\": \"사용자를 찾을 수 없습니다.\", \"data\": null }"))),
+                            examples = @ExampleObject(value = "{ \"code\": \"404\", \"message\": \"포인트를 찾을 수 없습니다.\", \"data\": null }"))),
             @ApiResponse(responseCode = "500", description = "서버 에러",
                     content = @Content(mediaType = "application/json",
                             examples = @ExampleObject(value = "{ \"code\": \"500\", \"message\": \"서버 에러\", \"data\": null }")))

--- a/src/main/java/team9502/sinchulgwinong/domain/point/dto/response/SavedPointDetailResponseDTO.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/point/dto/response/SavedPointDetailResponseDTO.java
@@ -1,0 +1,24 @@
+package team9502.sinchulgwinong.domain.point.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import team9502.sinchulgwinong.domain.point.enums.SpType;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SavedPointDetailResponseDTO {
+
+    @Schema(description = "적립된 포인트", example = "REVIEW")
+    private SpType type;
+
+    @Schema(description = "적립된 포인트", example = "100")
+    private Integer savedPoint;
+
+    @Schema(description = "적립된 날짜", example = "2021-07-01")
+    private LocalDate createdAt;
+}

--- a/src/main/java/team9502/sinchulgwinong/domain/point/repository/SavedPointRepositoryCustom.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/point/repository/SavedPointRepositoryCustom.java
@@ -1,13 +1,10 @@
 package team9502.sinchulgwinong.domain.point.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
 import team9502.sinchulgwinong.domain.point.entity.SavedPoint;
 
 import java.util.List;
 
-public interface SavedPointRepository extends JpaRepository<SavedPoint, Long>, SavedPointRepositoryCustom {
-
-    List<SavedPoint> findByPointPointId(Long pointId);
+public interface SavedPointRepositoryCustom {
 
     List<SavedPoint> findSavedPointsWithCursor(Long pointId, Long cursorId, int limit);
 }

--- a/src/main/java/team9502/sinchulgwinong/domain/point/repository/SavedPointRepositoryCustomImpl.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/point/repository/SavedPointRepositoryCustomImpl.java
@@ -1,0 +1,28 @@
+package team9502.sinchulgwinong.domain.point.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import team9502.sinchulgwinong.domain.point.entity.QSavedPoint;
+import team9502.sinchulgwinong.domain.point.entity.SavedPoint;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class SavedPointRepositoryCustomImpl implements SavedPointRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<SavedPoint> findSavedPointsWithCursor(Long pointId, Long cursorId, int limit) {
+        QSavedPoint qSavedPoint = QSavedPoint.savedPoint;
+        return queryFactory
+                .selectFrom(qSavedPoint)
+                .where(
+                        qSavedPoint.point.pointId.eq(pointId)
+                                .and(qSavedPoint.spId.lt(cursorId))
+                )
+                .orderBy(qSavedPoint.spId.desc())
+                .limit(limit)
+                .fetch();
+    }
+}

--- a/src/main/java/team9502/sinchulgwinong/domain/point/service/PointService.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/point/service/PointService.java
@@ -136,8 +136,7 @@ public class PointService {
     }
 
     @Transactional(readOnly = true)
-    public List<SavedPointDetailResponseDTO> getSpDetails(UserDetailsImpl userDetails) {
-
+    public List<SavedPointDetailResponseDTO> getSpDetails(UserDetailsImpl userDetails, Long cursorId, int limit) {
         Long pointId = null;
 
         Object user = userDetails.getUser();
@@ -151,11 +150,14 @@ public class PointService {
             throw new ApiException(ErrorCode.POINT_NOT_FOUND);
         }
 
-        List<SavedPoint> savedPoints = savedPointRepository.findByPointPointId(pointId);
+        // 커서 값이 null이면 최신 데이터부터 시작
+        if (cursorId == null) {
+            cursorId = Long.MAX_VALUE;
+        }
 
+        List<SavedPoint> savedPoints = savedPointRepository.findSavedPointsWithCursor(pointId, cursorId, limit);
         return savedPoints.stream()
                 .map(sp -> new SavedPointDetailResponseDTO(sp.getSpType(), sp.getSpAmount(), sp.getCreatedAt().toLocalDate()))
                 .collect(Collectors.toList());
     }
-
 }

--- a/src/main/java/team9502/sinchulgwinong/domain/point/service/PointService.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/point/service/PointService.java
@@ -7,6 +7,7 @@ import team9502.sinchulgwinong.domain.companyUser.entity.CompanyUser;
 import team9502.sinchulgwinong.domain.companyUser.repository.CompanyUserRepository;
 import team9502.sinchulgwinong.domain.point.CommonPoint;
 import team9502.sinchulgwinong.domain.point.dto.response.PointSummaryResponseDTO;
+import team9502.sinchulgwinong.domain.point.dto.response.SavedPointDetailResponseDTO;
 import team9502.sinchulgwinong.domain.point.entity.Point;
 import team9502.sinchulgwinong.domain.point.entity.SavedPoint;
 import team9502.sinchulgwinong.domain.point.entity.UsedPoint;
@@ -20,6 +21,9 @@ import team9502.sinchulgwinong.domain.user.repository.UserRepository;
 import team9502.sinchulgwinong.global.exception.ApiException;
 import team9502.sinchulgwinong.global.exception.ErrorCode;
 import team9502.sinchulgwinong.global.security.UserDetailsImpl;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -129,6 +133,29 @@ public class PointService {
                 .sum();
 
         return new PointSummaryResponseDTO(totalSaved, totalUsed);
+    }
+
+    @Transactional(readOnly = true)
+    public List<SavedPointDetailResponseDTO> getSpDetails(UserDetailsImpl userDetails) {
+
+        Long pointId = null;
+
+        Object user = userDetails.getUser();
+        if (user instanceof User) {
+            pointId = ((User) user).getPoint().getPointId();
+        } else if (user instanceof CompanyUser) {
+            pointId = ((CompanyUser) user).getPoint().getPointId();
+        }
+
+        if (pointId == null) {
+            throw new ApiException(ErrorCode.POINT_NOT_FOUND);
+        }
+
+        List<SavedPoint> savedPoints = savedPointRepository.findByPointPointId(pointId);
+
+        return savedPoints.stream()
+                .map(sp -> new SavedPointDetailResponseDTO(sp.getSpType(), sp.getSpAmount(), sp.getCreatedAt().toLocalDate()))
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/team9502/sinchulgwinong/global/config/SwaggerConfig.java
+++ b/src/main/java/team9502/sinchulgwinong/global/config/SwaggerConfig.java
@@ -1,10 +1,10 @@
 package team9502.sinchulgwinong.global.config;
 
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
+import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
-import io.swagger.v3.oas.models.OpenAPI;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
@@ -14,7 +14,16 @@ public class SwaggerConfig {
         return new OpenAPI()
                 .info(new Info()
                         .title("신출귀농 API 문서")
-                        .description("신출귀농 애플리케이션의 API 문서입니다.")
+                        .description("""
+                                ### 신출귀농 애플리케이션의 API 문서입니다.
+
+                                #### [백엔드 개발자]
+                                                               \s
+                                1. 김은채
+                                  ke808762@gmail.com
+                                                               \s
+                                2. 창다은
+                                  cdaeun95@gmail.com""")
                         .version("1.0.0")
                         .contact(new Contact()
                                 .name("9502")

--- a/src/main/java/team9502/sinchulgwinong/global/response/SuccessCode.java
+++ b/src/main/java/team9502/sinchulgwinong/global/response/SuccessCode.java
@@ -23,6 +23,7 @@ public enum SuccessCode {
 
     // Point
     SUCCESS_POINT_SUMMARY_READ(HttpStatus.OK, "포인트 총액 조회 성공"),
+    SUCCESS_SAVED_POINT_READ(HttpStatus.OK, "적립 포인트 조회 성공"),
 
     // Review
     SUCCESS_REVIEW_CREATION(HttpStatus.CREATED, "리뷰 작성 성공"),


### PR DESCRIPTION
주요 변경 사항을 간략하게 남기겠습니다.
1. 포인트 적립내역 조회 기능 추가
  * 포인트 적립 내역, 적립액, 생성 시간을 조회할 수 있습니다.
2. 페이지네이션
  * 무한스크롤 페이지네이션 방식을 통해 필요한 데이터만 가져오도록 최적화했습니다.
  * 'cursorId'와 'limit' 파라미터를 통해 페이지네이션을 구현했습니다.
3. API 문서 개선
  * Swagger문서에 백엔드 개발자 정보와 담당자를 추가하였습니다.