### PR TITLE
feature: 구인 게시글 CRUD 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,9 @@ dependencies {
     // Springdoc OpenAPI
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 
+    // S3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
     // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/src/main/java/team9502/sinchulgwinong/domain/jobBoard/controller/JobBoardController.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/jobBoard/controller/JobBoardController.java
@@ -1,0 +1,108 @@
+package team9502.sinchulgwinong.domain.jobBoard.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import team9502.sinchulgwinong.domain.jobBoard.dto.request.JobBoardRequestDTO;
+import team9502.sinchulgwinong.domain.jobBoard.dto.response.JobBoardResponseDTO;
+import team9502.sinchulgwinong.domain.jobBoard.service.JobBoardService;
+import team9502.sinchulgwinong.global.response.GlobalApiResponse;
+import team9502.sinchulgwinong.global.security.UserDetailsImpl;
+
+import java.util.List;
+
+import static team9502.sinchulgwinong.global.response.SuccessCode.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/jobBoards")
+@PreAuthorize("hasAuthority('ROLE_COMPANY')")
+public class JobBoardController {
+
+    private final JobBoardService jobBoardService;
+
+    @PostMapping
+    public ResponseEntity<GlobalApiResponse<JobBoardResponseDTO>> createJobBoard(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestPart(required = false, name = "images") List<MultipartFile> images,
+            @RequestPart(name = "request")@Valid JobBoardRequestDTO jobBoardRequestDTO) {
+
+        JobBoardResponseDTO jobBoardResponseDTO = jobBoardService.createJobBoard(userDetails.getCpUserId(), jobBoardRequestDTO, images);
+
+        return ResponseEntity.status(SUCCESS_CREATE_JOBBOARD.getHttpStatus())
+                .body(
+                        GlobalApiResponse.of(
+                                SUCCESS_CREATE_JOBBOARD.getMessage(),
+                                jobBoardResponseDTO
+                        )
+                );
+    }
+
+    @GetMapping
+    public ResponseEntity<GlobalApiResponse<List<JobBoardResponseDTO>>> getAllJobBoards() {
+
+        List<JobBoardResponseDTO> jobBoardResponseDTOS = jobBoardService.getAllJobBoards();
+
+        return ResponseEntity.status(SUCCESS_READ_ALL_JOBBOARD.getHttpStatus())
+                .body(
+                        GlobalApiResponse.of(
+                                SUCCESS_READ_ALL_JOBBOARD.getMessage(),
+                                jobBoardResponseDTOS
+                        )
+                );
+    }
+
+    @GetMapping("/{jobBoardId}")
+    public ResponseEntity<GlobalApiResponse<JobBoardResponseDTO>> getJobBoardById(
+            @PathVariable("jobBoardId") Long jobBoardId) {
+
+        JobBoardResponseDTO jobBoardResponseDTO = jobBoardService.getJobBoardById(jobBoardId);
+
+        return ResponseEntity.status(SUCCESS_READ_JOBBOARD.getHttpStatus())
+                .body(
+                        GlobalApiResponse.of(
+                                SUCCESS_READ_JOBBOARD.getMessage(),
+                                jobBoardResponseDTO
+                        )
+                );
+    }
+
+    @PatchMapping("/{jobBoardId}")
+    public ResponseEntity<GlobalApiResponse<JobBoardResponseDTO>> updateJobBoard(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable("jobBoardId") Long jobBoardId,
+            @RequestPart(required = false, name = "images") List<MultipartFile> images,
+            @RequestPart(name = "request") @Valid JobBoardRequestDTO jobBoardRequestDTO) {
+
+        JobBoardResponseDTO jobBoardResponseDTO = jobBoardService.updateJobBoard(userDetails.getCpUserId(), jobBoardId, jobBoardRequestDTO, images);
+
+        return ResponseEntity.status(SUCCESS_UPDATE_JOBBOARD.getHttpStatus())
+                .body(
+                        GlobalApiResponse.of(
+                                SUCCESS_UPDATE_JOBBOARD.getMessage(),
+                                jobBoardResponseDTO
+                        )
+                );
+    }
+
+    @DeleteMapping("/{jobBoardId}")
+    public ResponseEntity<GlobalApiResponse<Void>> deleteJobBoard(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable("jobBoardId") Long jobBoardId) {
+
+        jobBoardService.deleteJobBoard(userDetails.getCpUserId(), jobBoardId);
+
+        return ResponseEntity.status(SUCCESS_DELETE_JOBBOARD.getHttpStatus())
+                .body(
+                        GlobalApiResponse.of(
+                                SUCCESS_DELETE_JOBBOARD.getMessage(),
+                                null
+                        )
+                );
+    }
+
+}

--- a/src/main/java/team9502/sinchulgwinong/domain/jobBoard/dto/request/JobBoardRequestDTO.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/jobBoard/dto/request/JobBoardRequestDTO.java
@@ -1,0 +1,29 @@
+package team9502.sinchulgwinong.domain.jobBoard.dto.request;
+
+import lombok.Getter;
+import team9502.sinchulgwinong.domain.jobBoard.entity.JobStatus;
+import team9502.sinchulgwinong.domain.jobBoard.entity.SalaryType;
+
+import java.time.LocalDate;
+
+@Getter
+public class JobBoardRequestDTO {
+
+    private String jobTitle;
+
+    private String jobContent;
+
+    private LocalDate jobStartDate;
+
+    private LocalDate jobEndDate;
+
+    private Integer salaryAmount;
+
+    private String sex;
+
+    private String address;
+
+    private JobStatus jobStatus;
+
+    private SalaryType salaryType;
+}

--- a/src/main/java/team9502/sinchulgwinong/domain/jobBoard/dto/request/JobBoardRequestDTO.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/jobBoard/dto/request/JobBoardRequestDTO.java
@@ -1,5 +1,6 @@
 package team9502.sinchulgwinong.domain.jobBoard.dto.request;
 
+import jakarta.validation.constraints.FutureOrPresent;
 import lombok.Getter;
 import team9502.sinchulgwinong.domain.jobBoard.entity.JobStatus;
 import team9502.sinchulgwinong.domain.jobBoard.entity.SalaryType;
@@ -13,8 +14,10 @@ public class JobBoardRequestDTO {
 
     private String jobContent;
 
+    @FutureOrPresent
     private LocalDate jobStartDate;
 
+    @FutureOrPresent
     private LocalDate jobEndDate;
 
     private Integer salaryAmount;

--- a/src/main/java/team9502/sinchulgwinong/domain/jobBoard/dto/response/JobBoardResponseDTO.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/jobBoard/dto/response/JobBoardResponseDTO.java
@@ -1,0 +1,56 @@
+package team9502.sinchulgwinong.domain.jobBoard.dto.response;
+
+import lombok.Getter;
+import team9502.sinchulgwinong.domain.jobBoard.entity.BoardImage;
+import team9502.sinchulgwinong.domain.jobBoard.entity.JobBoard;
+import team9502.sinchulgwinong.domain.jobBoard.entity.JobStatus;
+import team9502.sinchulgwinong.domain.jobBoard.entity.SalaryType;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class JobBoardResponseDTO {
+
+    private Long jobBoardId;
+
+    private Long cpUserId;
+
+    private String jobTitle;
+
+    private String jobContent;
+
+    private LocalDate jobStartDate;
+
+    private LocalDate jobEndDate;
+
+    private Integer salaryAmount;
+
+    private String sex;
+
+    private String address;
+
+    private JobStatus jobStatus;
+
+    private SalaryType salaryType;
+
+    private List<String> accessUrls;
+
+    public JobBoardResponseDTO(JobBoard jobBoard) {
+        this.jobBoardId = jobBoard.getJobBoardId();
+        this.cpUserId = jobBoard.getCompanyUser().getCpUserId();
+        this.jobTitle = jobBoard.getJobTitle();
+        this.jobContent = jobBoard.getJobContent();
+        this.salaryType = jobBoard.getSalaryType();
+        this.jobStatus = jobBoard.getJobStatus();
+        this.address = jobBoard.getAddress();
+        this.sex = jobBoard.getSex();
+        this.salaryAmount = jobBoard.getSalaryAmount();
+        this.jobStartDate = jobBoard.getJobStartDate();
+        this.jobEndDate = jobBoard.getJobEndDate();
+        this.accessUrls = jobBoard.getBoardImage().stream()
+                .map(BoardImage::getAccessUrl)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/team9502/sinchulgwinong/domain/jobBoard/dto/response/JobBoardResponseDTO.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/jobBoard/dto/response/JobBoardResponseDTO.java
@@ -7,6 +7,7 @@ import team9502.sinchulgwinong.domain.jobBoard.entity.JobStatus;
 import team9502.sinchulgwinong.domain.jobBoard.entity.SalaryType;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -37,6 +38,10 @@ public class JobBoardResponseDTO {
 
     private List<String> accessUrls;
 
+    private LocalDateTime createdAt;
+
+    private LocalDateTime modifiedAt;
+
     public JobBoardResponseDTO(JobBoard jobBoard) {
         this.jobBoardId = jobBoard.getJobBoardId();
         this.cpUserId = jobBoard.getCompanyUser().getCpUserId();
@@ -52,5 +57,7 @@ public class JobBoardResponseDTO {
         this.accessUrls = jobBoard.getBoardImage().stream()
                 .map(BoardImage::getAccessUrl)
                 .collect(Collectors.toList());
+        this.createdAt = jobBoard.getCreatedAt();
+        this.modifiedAt = jobBoard.getModifiedAt();
     }
 }

--- a/src/main/java/team9502/sinchulgwinong/domain/jobBoard/entity/BoardImage.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/jobBoard/entity/BoardImage.java
@@ -1,0 +1,51 @@
+package team9502.sinchulgwinong.domain.jobBoard.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class BoardImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column
+    private Long id;
+
+    @Setter
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "job_board_id")
+    private JobBoard jobBoard;
+
+    private String originName; // 이미지 파일의 본래 이름
+
+    private String storedName; // 이미지 파일이 S3에 저장될때 사용되는 이름
+
+    @Setter
+    private String accessUrl; // S3 내부 이미지에 접근할 수 있는 URL
+
+    public BoardImage(String originName) {
+        this.originName = originName;
+        this.storedName = getFileName(originName);
+        this.accessUrl = "";
+    }
+
+    // 이미지 파일의 확장자를 추출하는 메소드
+    public String extractExtension(String originName) {
+        int index = originName.lastIndexOf('.');
+        if (index == -1) {
+            return ""; // 확장자가 없으면 빈 문자열 반환
+        }
+        return originName.substring(index + 1);
+    }
+
+    // 이미지 파일의 이름을 저장하기 위한 이름으로 변환하는 메소드
+    public String getFileName(String originName) {
+        return UUID.randomUUID() + "." + extractExtension(originName);
+    }
+}

--- a/src/main/java/team9502/sinchulgwinong/domain/jobBoard/entity/JobBoard.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/jobBoard/entity/JobBoard.java
@@ -1,0 +1,68 @@
+package team9502.sinchulgwinong.domain.jobBoard.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import team9502.sinchulgwinong.domain.companyUser.entity.CompanyUser;
+import team9502.sinchulgwinong.global.entity.BaseTimeEntity;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+public class JobBoard extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long jobBoardId;
+
+    @Setter
+    @ManyToOne
+    @JoinColumn(name = "cpUserId", nullable = false)
+    private CompanyUser companyUser;
+
+    @Setter
+    @OneToMany(mappedBy = "jobBoard", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<BoardImage> boardImage = new ArrayList<>();
+
+    @Setter
+    @Column(length = 100, nullable = false)
+    private String jobTitle;
+
+    @Setter
+    @Column(length = 1000)
+    private String jobContent;
+
+    @Setter
+    @Column(nullable = false)
+    private LocalDate jobStartDate;
+
+    @Setter
+    @Column(nullable = false)
+    private LocalDate jobEndDate;
+
+    @Setter
+    @Column(nullable = false)
+    private Integer salaryAmount;
+
+    @Setter
+    @Column(nullable = false)
+    private String sex;
+
+    @Setter
+    @Column(nullable = false)
+    private String address;
+
+    @Setter
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private JobStatus jobStatus;
+
+    @Setter
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private SalaryType salaryType;
+
+}

--- a/src/main/java/team9502/sinchulgwinong/domain/jobBoard/entity/JobStatus.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/jobBoard/entity/JobStatus.java
@@ -1,0 +1,10 @@
+package team9502.sinchulgwinong.domain.jobBoard.entity;
+
+public enum JobStatus {
+
+    // JOBOPEN: 채용중
+    // JOBCLOSED: 채용마감
+
+    JOBOPEN,
+    JOBCLOSED
+}

--- a/src/main/java/team9502/sinchulgwinong/domain/jobBoard/entity/SalaryType.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/jobBoard/entity/SalaryType.java
@@ -1,0 +1,12 @@
+package team9502.sinchulgwinong.domain.jobBoard.entity;
+
+public enum SalaryType {
+
+    // DAILY: 일급
+    // WEEKLY: 주급
+    // MONTHLY: 월급
+
+    DAILY,
+    WEEKLY,
+    MONTHLY
+}

--- a/src/main/java/team9502/sinchulgwinong/domain/jobBoard/repository/BoardImageRepository.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/jobBoard/repository/BoardImageRepository.java
@@ -1,0 +1,7 @@
+package team9502.sinchulgwinong.domain.jobBoard.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team9502.sinchulgwinong.domain.jobBoard.entity.BoardImage;
+
+public interface BoardImageRepository extends JpaRepository<BoardImage, Long> {
+}

--- a/src/main/java/team9502/sinchulgwinong/domain/jobBoard/repository/JobBoardRepository.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/jobBoard/repository/JobBoardRepository.java
@@ -1,0 +1,7 @@
+package team9502.sinchulgwinong.domain.jobBoard.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team9502.sinchulgwinong.domain.jobBoard.entity.JobBoard;
+
+public interface JobBoardRepository extends JpaRepository<JobBoard, Long> {
+}

--- a/src/main/java/team9502/sinchulgwinong/domain/jobBoard/service/JobBoardService.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/jobBoard/service/JobBoardService.java
@@ -1,0 +1,215 @@
+package team9502.sinchulgwinong.domain.jobBoard.service;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import team9502.sinchulgwinong.domain.companyUser.entity.CompanyUser;
+import team9502.sinchulgwinong.domain.companyUser.repository.CompanyUserRepository;
+import team9502.sinchulgwinong.domain.jobBoard.dto.request.JobBoardRequestDTO;
+import team9502.sinchulgwinong.domain.jobBoard.dto.response.JobBoardResponseDTO;
+import team9502.sinchulgwinong.domain.jobBoard.entity.BoardImage;
+import team9502.sinchulgwinong.domain.jobBoard.entity.JobBoard;
+import team9502.sinchulgwinong.domain.jobBoard.repository.BoardImageRepository;
+import team9502.sinchulgwinong.domain.jobBoard.repository.JobBoardRepository;
+import team9502.sinchulgwinong.domain.point.enums.SpType;
+import team9502.sinchulgwinong.domain.point.service.PointService;
+import team9502.sinchulgwinong.global.exception.ApiException;
+import team9502.sinchulgwinong.global.exception.ErrorCode;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class JobBoardService {
+
+    @Value("${S3_NAME}")
+    private String bucketName;
+
+    private final JobBoardRepository jobBoardRepository;
+    private final CompanyUserRepository companyUserRepository;
+    private final BoardImageRepository boardImageRepository;
+    private final PointService pointService;
+    private final AmazonS3Client amazonS3Client;
+
+    @Transactional
+    public JobBoardResponseDTO createJobBoard(
+            Long cpUserID,
+            JobBoardRequestDTO jobBoardRequestDTO,
+            List<MultipartFile> multipartFile){
+
+        validation(jobBoardRequestDTO);
+
+        CompanyUser companyUser = companyUserRepository.findById(cpUserID)
+                .orElseThrow(()-> new ApiException(ErrorCode.COMPANY_USER_NOT_FOUND));
+
+        JobBoard jobBoard = new JobBoard();
+
+        jobBoard.setCompanyUser(companyUser);
+        jobBoard.setJobTitle(jobBoardRequestDTO.getJobTitle());
+        jobBoard.setJobContent(jobBoardRequestDTO.getJobContent());
+        jobBoard.setJobStartDate(jobBoardRequestDTO.getJobStartDate());
+        jobBoard.setJobEndDate(jobBoardRequestDTO.getJobEndDate());
+        jobBoard.setSalaryAmount(jobBoardRequestDTO.getSalaryAmount());
+        jobBoard.setSex(jobBoardRequestDTO.getSex());
+        jobBoard.setAddress(jobBoardRequestDTO.getAddress());
+        jobBoard.setJobStatus(jobBoardRequestDTO.getJobStatus());
+        jobBoard.setSalaryType(jobBoardRequestDTO.getSalaryType());
+
+
+        // 실제로 파일 데이터를 포함하고 있는 파일만 처리
+        List<MultipartFile> validFiles = multipartFile.stream()
+                .filter(multipartFiles -> !multipartFiles.isEmpty())
+                .collect(Collectors.toList());
+
+        if (!validFiles.isEmpty()) {
+            List<BoardImage> boardImageList = saveBoardImages(validFiles, jobBoard);
+            jobBoard.setBoardImage(boardImageList);
+        }
+
+
+        jobBoardRepository.save(jobBoard);
+
+        pointService.earnPoints(companyUser, SpType.JOBS);
+
+        return new JobBoardResponseDTO(jobBoard);
+    }
+
+    // 게시글 이미지 저장
+    public List<BoardImage> saveBoardImages(List<MultipartFile> multipartFiles, JobBoard jobBoard) {
+
+        List<BoardImage> boardImages = new ArrayList<>();
+
+        for (MultipartFile multipartFile : multipartFiles) {
+            BoardImage image = saveImageBo(multipartFile, jobBoard);
+            boardImages.add(image);
+        }
+
+        return boardImages;
+    }
+
+    public BoardImage saveImageBo(MultipartFile multipartFile, JobBoard jobBoard) {
+
+        String originalName = multipartFile.getOriginalFilename();
+        BoardImage boardImage = new BoardImage(originalName);
+        boardImage.setJobBoard(jobBoard);
+
+        String filename = boardImage.getStoredName();
+
+        try {
+            ObjectMetadata objectMetadata = new ObjectMetadata();
+            objectMetadata.setContentType(multipartFile.getContentType());
+            objectMetadata.setContentLength(multipartFile.getInputStream().available());
+
+            amazonS3Client.putObject(bucketName, filename, multipartFile.getInputStream(), objectMetadata);
+            String accessUrl = amazonS3Client.getUrl(bucketName, filename).toString();
+            boardImage.setAccessUrl(accessUrl);
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        boardImageRepository.save(boardImage);
+
+        return boardImage;
+    }
+
+    @Transactional(readOnly = true)
+    public List<JobBoardResponseDTO> getAllJobBoards(){
+
+        return jobBoardRepository.findAll().stream()
+                .map(JobBoardResponseDTO::new)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public JobBoardResponseDTO getJobBoardById(Long jobBoardId){
+
+        JobBoard jobBoard = jobBoardRepository.findById(jobBoardId)
+                .orElseThrow(()-> new ApiException(ErrorCode.BOARD_NOT_FOUND));
+
+        return new JobBoardResponseDTO(jobBoard);
+    }
+
+    @Transactional
+    public JobBoardResponseDTO updateJobBoard(
+            Long cpUserId,
+            Long jobBoardId,
+            JobBoardRequestDTO jobBoardRequestDTO,
+            List<MultipartFile> multipartFile){
+
+        JobBoard jobBoard = jobBoardRepository.findById(jobBoardId)
+                .orElseThrow(() -> new ApiException(ErrorCode.BOARD_NOT_FOUND));
+
+        if (!jobBoard.getCompanyUser().getCpUserId().equals(cpUserId)) {
+            throw new ApiException(ErrorCode.FORBIDDEN_WORK);
+        }
+
+        validation(jobBoardRequestDTO);
+
+        jobBoard.setJobTitle(jobBoardRequestDTO.getJobTitle());
+        jobBoard.setJobContent(jobBoardRequestDTO.getJobContent());
+        jobBoard.setModifiedAt(LocalDateTime.now());
+
+        // 실제로 파일 데이터를 포함하고 있는 파일만 처리
+        List<MultipartFile> validFiles = multipartFile.stream()
+                .filter(multipartFiles -> !multipartFiles.isEmpty())
+                .collect(Collectors.toList());
+
+        if (!validFiles.isEmpty()) {
+            List<BoardImage> existingImages = jobBoard.getBoardImage();
+            List<BoardImage> newImages = saveBoardImages(validFiles, jobBoard);
+            existingImages.addAll(newImages);
+            jobBoard.setBoardImage(existingImages);
+        }
+
+        jobBoardRepository.save(jobBoard);
+
+        return new JobBoardResponseDTO(jobBoard);
+    }
+
+    @Transactional
+    public void deleteJobBoard(Long cpUserId, Long jobBoardId){
+
+        JobBoard jobBoard = jobBoardRepository.findById(jobBoardId)
+                .orElseThrow(() -> new ApiException(ErrorCode.BOARD_NOT_FOUND));
+
+        if (!jobBoard.getCompanyUser().getCpUserId().equals(cpUserId)) {
+            throw new ApiException(ErrorCode.FORBIDDEN_WORK);
+        }
+
+        for (BoardImage boardImage : jobBoard.getBoardImage()) {
+
+            DeleteObjectRequest request = new DeleteObjectRequest(bucketName, boardImage.getStoredName());
+            amazonS3Client.deleteObject(request); // S3에서 이미지 삭제
+        }
+
+        jobBoardRepository.delete(jobBoard);
+    }
+
+
+    private void validation(JobBoardRequestDTO jobBoardRequestDTO) {
+
+        if (jobBoardRequestDTO.getJobTitle().isEmpty()) {
+            throw new ApiException(ErrorCode.TITLE_REQUIRED);
+        }
+        if (jobBoardRequestDTO.getJobContent().isEmpty()) {
+            throw new ApiException(ErrorCode.CONTENT_REQUIRED);
+        }
+        if (jobBoardRequestDTO.getJobTitle().length() > 100) {
+            throw new ApiException(ErrorCode.TITLE_TOO_LONG);
+        }
+        if (jobBoardRequestDTO.getJobContent().length() > 1000) {
+            throw new ApiException(ErrorCode.CONTENT_TOO_LONG);
+        }
+    }
+
+}

--- a/src/main/java/team9502/sinchulgwinong/global/config/S3Config.java
+++ b/src/main/java/team9502/sinchulgwinong/global/config/S3Config.java
@@ -1,0 +1,33 @@
+package team9502.sinchulgwinong.global.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${S3_ACCESS_KEY}")
+    private String accessKey;
+
+    @Value("${SECRET_ACCESS_KEY}")
+    private String secretKey;
+
+    @Value("${S3_REGION}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+
+        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+}

--- a/src/main/java/team9502/sinchulgwinong/global/response/SuccessCode.java
+++ b/src/main/java/team9502/sinchulgwinong/global/response/SuccessCode.java
@@ -24,6 +24,13 @@ public enum SuccessCode {
     // Point
     SUCCESS_POINT_SUMMARY_READ(HttpStatus.OK, "포인트 총액 조회 성공"),
 
+    //JobBoard
+    SUCCESS_CREATE_JOBBOARD(HttpStatus.CREATED, "구인게시글 생성 성공"),
+    SUCCESS_READ_ALL_JOBBOARD(HttpStatus.OK, "구인게시글 전체 조회 성공"),
+    SUCCESS_READ_JOBBOARD(HttpStatus.OK, "구인게시글 단건 조회 성공"),
+    SUCCESS_UPDATE_JOBBOARD(HttpStatus.OK, "구인게시글 업데이트 성공"),
+    SUCCESS_DELETE_JOBBOARD(HttpStatus.OK, "구인게시글 삭제 성공"),
+
     // Review
     SUCCESS_REVIEW_CREATION(HttpStatus.CREATED, "리뷰 작성 성공"),
     SUCCESS_CP_USER_REVIEW_READ(HttpStatus.OK, "기업 리뷰 전체 조회 성공"),

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -28,3 +28,13 @@ jwt:
 
 encryption:
   secretKey: ${ENCRYPTION_SECRET_KEY}
+
+cloud:
+  aws:
+    s3:
+      bucket: ${S3_NAME}
+    stack.auto: false
+    region.static: ${S3_REGION}
+    credentials:
+      accessKey: ${S3_ACCESS_KEY}
+      secretKey: ${SECRET_ACCESS_KEY}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -21,3 +21,13 @@ jwt:
 
 encryption:
   secretKey: ${ENCRYPTION_SECRET_KEY}
+
+cloud:
+  aws:
+    s3:
+      bucket: ${S3_NAME}
+    stack.auto: false
+    region.static: ${S3_REGION}
+    credentials:
+      accessKey: ${S3_ACCESS_KEY}
+      secretKey: ${SECRET_ACCESS_KEY}


### PR DESCRIPTION
1. 구인 게시글 생성, 수정시 글과 함께 S3에 이미지 업로드가 가능하도록 구현했습니다.
2. jobStartDate, jobEndDate 은 연-월-일 만 받아오는 값입니다. 불필요한 정보가 담긴 LocalDateTime이 아니라 LocalDate 으로 받아오도록 설정했습니다.
4. 구인 게시글 전체 조회, 단건 조회를 구현했습니다.
5. 구인 게시글 삭제시 S3에 이미지도 자동으로 삭제하는 로직을 구현했습니다.
6. 이미지 정보는 BoardImage 엔티티와 레포지토리에서 따로 관리하도록 분리 했습니다.