### PR TITLE
feat: 포인트 사용 내역 조회 + 페이지네이션(무한스크롤) 적용

### DIFF
--- a/src/main/java/team9502/sinchulgwinong/domain/point/controller/PointController.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/point/controller/PointController.java
@@ -15,14 +15,14 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import team9502.sinchulgwinong.domain.point.dto.response.PointSummaryResponseDTO;
 import team9502.sinchulgwinong.domain.point.dto.response.SavedPointDetailResponseDTO;
+import team9502.sinchulgwinong.domain.point.dto.response.UsedPointDetailResponseDTO;
 import team9502.sinchulgwinong.domain.point.service.PointService;
 import team9502.sinchulgwinong.global.response.GlobalApiResponse;
 import team9502.sinchulgwinong.global.security.UserDetailsImpl;
 
 import java.util.List;
 
-import static team9502.sinchulgwinong.global.response.SuccessCode.SUCCESS_POINT_SUMMARY_READ;
-import static team9502.sinchulgwinong.global.response.SuccessCode.SUCCESS_SAVED_POINT_READ;
+import static team9502.sinchulgwinong.global.response.SuccessCode.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -87,6 +87,33 @@ public class PointController {
                 .body(
                         GlobalApiResponse.of(
                                 SUCCESS_SAVED_POINT_READ.getMessage(),
+                                responseDTOs
+                        )
+                );
+    }
+
+    @GetMapping("/used-details")
+    @Operation(summary = "포인트 사용 내역 조회", description = "로그인한 사용자의 포인트 사용 내역을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "포인트 사용 내역 조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = "{ \"code\": \"200\", \"message\": \"포인트 사용 내역 조회 성공\", \"data\": [{\"type\": \"REVIEW\", \"upAmount\": 100, \"usedAt\": \"2024-06-11\"}, {\"type\": \"BANNER\", \"upAmount\": 50, \"usedAt\": \"2024-06-10\"}] }"))),
+            @ApiResponse(responseCode = "404", description = "포인트를 찾을 수 없습니다.",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = "{ \"code\": \"404\", \"message\": \"포인트를 찾을 수 없습니다.\", \"data\": null }"))),
+            @ApiResponse(responseCode = "500", description = "서버 에러",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = "{ \"code\": \"500\", \"message\": \"서버 에러\", \"data\": null }")))
+    })
+    public ResponseEntity<GlobalApiResponse<List<UsedPointDetailResponseDTO>>> getUsedPointDetails(
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        List<UsedPointDetailResponseDTO> responseDTOs = pointService.getUpDetails(userDetails);
+
+        return ResponseEntity.status(SUCCESS_USED_POINT_READ.getHttpStatus())
+                .body(
+                        GlobalApiResponse.of(
+                                SUCCESS_USED_POINT_READ.getMessage(),
                                 responseDTOs
                         )
                 );

--- a/src/main/java/team9502/sinchulgwinong/domain/point/controller/PointController.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/point/controller/PointController.java
@@ -59,7 +59,7 @@ public class PointController {
                 );
     }
 
-    @GetMapping("/details")
+    @GetMapping("/saved")
     @Operation(summary = "포인트 적립 내역 조회", description = "로그인한 사용자의 포인트 적립 내역을 커서 기반 페이지네이션으로 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "포인트 적립 내역 조회 성공",
@@ -92,7 +92,7 @@ public class PointController {
                 );
     }
 
-    @GetMapping("/used-details")
+    @GetMapping("/used")
     @Operation(summary = "포인트 사용 내역 조회", description = "로그인한 사용자의 포인트 사용 내역을 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "포인트 사용 내역 조회 성공",
@@ -106,9 +106,11 @@ public class PointController {
                             examples = @ExampleObject(value = "{ \"code\": \"500\", \"message\": \"서버 에러\", \"data\": null }")))
     })
     public ResponseEntity<GlobalApiResponse<List<UsedPointDetailResponseDTO>>> getUsedPointDetails(
-            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestParam(value = "cursorId", required = false) Long cursorId,
+            @RequestParam(value = "limit", defaultValue = "6") int limit) {
 
-        List<UsedPointDetailResponseDTO> responseDTOs = pointService.getUpDetails(userDetails);
+        List<UsedPointDetailResponseDTO> responseDTOs = pointService.getUpDetails(userDetails, cursorId, limit);
 
         return ResponseEntity.status(SUCCESS_USED_POINT_READ.getHttpStatus())
                 .body(

--- a/src/main/java/team9502/sinchulgwinong/domain/point/dto/response/UsedPointDetailResponseDTO.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/point/dto/response/UsedPointDetailResponseDTO.java
@@ -14,10 +14,10 @@ import java.time.LocalDate;
 public class UsedPointDetailResponseDTO {
 
     @Schema(description = "사용된 포인트", example = "REVIEW")
-    private UpType upType;
+    private UpType type;
 
     @Schema(description = "사용된 포인트", example = "100")
-    private Integer upAmount;
+    private Integer usedPoint;
 
     @Schema(description = "사용된 날짜", example = "2021-07-01")
     private LocalDate usedAt;

--- a/src/main/java/team9502/sinchulgwinong/domain/point/dto/response/UsedPointDetailResponseDTO.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/point/dto/response/UsedPointDetailResponseDTO.java
@@ -1,0 +1,24 @@
+package team9502.sinchulgwinong.domain.point.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import team9502.sinchulgwinong.domain.point.enums.UpType;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UsedPointDetailResponseDTO {
+
+    @Schema(description = "사용된 포인트", example = "REVIEW")
+    private UpType upType;
+
+    @Schema(description = "사용된 포인트", example = "100")
+    private Integer upAmount;
+
+    @Schema(description = "사용된 날짜", example = "2021-07-01")
+    private LocalDate usedAt;
+}

--- a/src/main/java/team9502/sinchulgwinong/domain/point/repository/UsedPointRepository.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/point/repository/UsedPointRepository.java
@@ -5,7 +5,7 @@ import team9502.sinchulgwinong.domain.point.entity.UsedPoint;
 
 import java.util.List;
 
-public interface UsedPointRepository extends JpaRepository<UsedPoint, Long> {
+public interface UsedPointRepository extends JpaRepository<UsedPoint, Long>, UsedPointRepositoryCustom {
 
     List<UsedPoint> findByPointPointId(Long pointId);
 }

--- a/src/main/java/team9502/sinchulgwinong/domain/point/repository/UsedPointRepositoryCustom.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/point/repository/UsedPointRepositoryCustom.java
@@ -1,0 +1,10 @@
+package team9502.sinchulgwinong.domain.point.repository;
+
+import team9502.sinchulgwinong.domain.point.entity.UsedPoint;
+
+import java.util.List;
+
+public interface UsedPointRepositoryCustom {
+
+    List<UsedPoint> findUsedPointsWithCursor(Long pointId, Long cursorId, int limit);
+}

--- a/src/main/java/team9502/sinchulgwinong/domain/point/repository/UsedPointRepositoryCustomImpl.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/point/repository/UsedPointRepositoryCustomImpl.java
@@ -1,0 +1,28 @@
+package team9502.sinchulgwinong.domain.point.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import team9502.sinchulgwinong.domain.point.entity.QUsedPoint;
+import team9502.sinchulgwinong.domain.point.entity.UsedPoint;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class UsedPointRepositoryCustomImpl implements UsedPointRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<UsedPoint> findUsedPointsWithCursor(Long pointId, Long cursorId, int limit) {
+        QUsedPoint qUsedPoint = QUsedPoint.usedPoint;
+        return queryFactory
+                .selectFrom(qUsedPoint)
+                .where(
+                        qUsedPoint.point.pointId.eq(pointId)
+                                .and(qUsedPoint.upId.lt(cursorId))
+                )
+                .orderBy(qUsedPoint.upId.desc())
+                .limit(limit)
+                .fetch();
+    }
+}

--- a/src/main/java/team9502/sinchulgwinong/domain/point/service/PointService.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/point/service/PointService.java
@@ -8,6 +8,7 @@ import team9502.sinchulgwinong.domain.companyUser.repository.CompanyUserReposito
 import team9502.sinchulgwinong.domain.point.CommonPoint;
 import team9502.sinchulgwinong.domain.point.dto.response.PointSummaryResponseDTO;
 import team9502.sinchulgwinong.domain.point.dto.response.SavedPointDetailResponseDTO;
+import team9502.sinchulgwinong.domain.point.dto.response.UsedPointDetailResponseDTO;
 import team9502.sinchulgwinong.domain.point.entity.Point;
 import team9502.sinchulgwinong.domain.point.entity.SavedPoint;
 import team9502.sinchulgwinong.domain.point.entity.UsedPoint;
@@ -158,6 +159,30 @@ public class PointService {
         List<SavedPoint> savedPoints = savedPointRepository.findSavedPointsWithCursor(pointId, cursorId, limit);
         return savedPoints.stream()
                 .map(sp -> new SavedPointDetailResponseDTO(sp.getSpType(), sp.getSpAmount(), sp.getCreatedAt().toLocalDate()))
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public List<UsedPointDetailResponseDTO> getUpDetails(UserDetailsImpl userDetails) {
+
+        Object user = userDetails.getUser();
+        Point point;
+
+        if (user instanceof User) {
+            point = ((User) user).getPoint();
+        } else if (user instanceof CompanyUser) {
+            point = ((CompanyUser) user).getPoint();
+        } else {
+            throw new ApiException(ErrorCode.INVALID_USER_TYPE);
+        }
+
+        if (point == null) {
+            throw new ApiException(ErrorCode.POINT_NOT_FOUND);
+        }
+
+        List<UsedPoint> usedPoints = usedPointRepository.findByPointPointId(point.getPointId());
+        return usedPoints.stream()
+                .map(up -> new UsedPointDetailResponseDTO(up.getUpType(), up.getUpAmount(), up.getCreatedAt().toLocalDate()))
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/team9502/sinchulgwinong/domain/point/service/PointService.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/point/service/PointService.java
@@ -137,56 +137,60 @@ public class PointService {
     }
 
     @Transactional(readOnly = true)
-    public List<SavedPointDetailResponseDTO> getSpDetails(UserDetailsImpl userDetails, Long cursorId, int limit) {
-        Long pointId = null;
+    public List<SavedPointDetailResponseDTO> getSpDetails(UserDetailsImpl userDetails, Long cursorId, int limit) throws ApiException {
 
-        Object user = userDetails.getUser();
-        if (user instanceof User) {
-            pointId = ((User) user).getPoint().getPointId();
-        } else if (user instanceof CompanyUser) {
-            pointId = ((CompanyUser) user).getPoint().getPointId();
-        }
+        Long pointId = getPointId(userDetails);
 
-        if (pointId == null) {
-            throw new ApiException(ErrorCode.POINT_NOT_FOUND);
-        }
-
-        // 커서 값이 null이면 최신 데이터부터 시작
         if (cursorId == null) {
             cursorId = Long.MAX_VALUE;
         }
-
         List<SavedPoint> savedPoints = savedPointRepository.findSavedPointsWithCursor(pointId, cursorId, limit);
+
         return savedPoints.stream()
                 .map(sp -> new SavedPointDetailResponseDTO(sp.getSpType(), sp.getSpAmount(), sp.getCreatedAt().toLocalDate()))
                 .collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)
-    public List<UsedPointDetailResponseDTO> getUpDetails(UserDetailsImpl userDetails, Long cursorId, int limit) {
+    public List<UsedPointDetailResponseDTO> getUpDetails(UserDetailsImpl userDetails, Long cursorId, int limit) throws ApiException {
+
+        Long pointId = getPointId(userDetails);
+
+        if (cursorId == null) {
+            cursorId = Long.MAX_VALUE;
+        }
+        List<UsedPoint> usedPoints = usedPointRepository.findUsedPointsWithCursor(pointId, cursorId, limit);
+
+        return usedPoints.stream()
+                .map(up -> new UsedPointDetailResponseDTO(up.getUpType(), up.getUpAmount(), up.getCreatedAt().toLocalDate()))
+                .collect(Collectors.toList());
+    }
+
+    /*
+        공통 로직을 메서드로 추출
+     */
+
+    private Point getUserPoint(UserDetailsImpl userDetails) throws ApiException {
 
         Object user = userDetails.getUser();
-        Point point;
 
         if (user instanceof User) {
-            point = ((User) user).getPoint();
+            return ((User) user).getPoint();
         } else if (user instanceof CompanyUser) {
-            point = ((CompanyUser) user).getPoint();
+            return ((CompanyUser) user).getPoint();
         } else {
             throw new ApiException(ErrorCode.INVALID_USER_TYPE);
         }
+    }
+
+    private Long getPointId(UserDetailsImpl userDetails) throws ApiException {
+
+        Point point = getUserPoint(userDetails);
 
         if (point == null) {
             throw new ApiException(ErrorCode.POINT_NOT_FOUND);
         }
 
-        if (cursorId == null) {
-            cursorId = Long.MAX_VALUE;
-        }
-
-        List<UsedPoint> usedPoints = usedPointRepository.findUsedPointsWithCursor(point.getPointId(), cursorId, limit);
-        return usedPoints.stream()
-                .map(up -> new UsedPointDetailResponseDTO(up.getUpType(), up.getUpAmount(), up.getCreatedAt().toLocalDate()))
-                .collect(Collectors.toList());
+        return point.getPointId();
     }
 }

--- a/src/main/java/team9502/sinchulgwinong/domain/point/service/PointService.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/point/service/PointService.java
@@ -163,7 +163,7 @@ public class PointService {
     }
 
     @Transactional(readOnly = true)
-    public List<UsedPointDetailResponseDTO> getUpDetails(UserDetailsImpl userDetails) {
+    public List<UsedPointDetailResponseDTO> getUpDetails(UserDetailsImpl userDetails, Long cursorId, int limit) {
 
         Object user = userDetails.getUser();
         Point point;
@@ -180,7 +180,11 @@ public class PointService {
             throw new ApiException(ErrorCode.POINT_NOT_FOUND);
         }
 
-        List<UsedPoint> usedPoints = usedPointRepository.findByPointPointId(point.getPointId());
+        if (cursorId == null) {
+            cursorId = Long.MAX_VALUE;
+        }
+
+        List<UsedPoint> usedPoints = usedPointRepository.findUsedPointsWithCursor(point.getPointId(), cursorId, limit);
         return usedPoints.stream()
                 .map(up -> new UsedPointDetailResponseDTO(up.getUpType(), up.getUpAmount(), up.getCreatedAt().toLocalDate()))
                 .collect(Collectors.toList());

--- a/src/main/java/team9502/sinchulgwinong/global/response/SuccessCode.java
+++ b/src/main/java/team9502/sinchulgwinong/global/response/SuccessCode.java
@@ -24,6 +24,7 @@ public enum SuccessCode {
     // Point
     SUCCESS_POINT_SUMMARY_READ(HttpStatus.OK, "포인트 총액 조회 성공"),
     SUCCESS_SAVED_POINT_READ(HttpStatus.OK, "적립 포인트 조회 성공"),
+    SUCCESS_USED_POINT_READ(HttpStatus.OK, "사용 포인트 조회 성공"),
 
     //JobBoard
     SUCCESS_CREATE_JOBBOARD(HttpStatus.CREATED, "구인게시글 생성 성공"),


### PR DESCRIPTION
1. 커서 기반 페이지네이션 구현
    *  getSavedPointDetails 및 getUsedPointDetails 메소드에 커서 기반 페이지네이션을 적용하여, 대용량 데이터 처리 시 성능과 효율성을 개선했습니다.
3. API 경로 개선
    *  기존의 /points/used-details 경로를 /points/used로 변경하여 API가 보다 RESTful하게 동작하도록 개선했습니다.
5. Swagger 문서 업데이트: 
    *  cursorId와 limit 매개변수에 대한 상세 설명을 추가하여 API 문서를 개선했습니다. 이로써 팀원들이 API를 보다 쉽게 사용할 수 있습니다.