### PR TITLE
fix: 게시글 응답 값 수정, 스크랩 버그 수정

### DIFF
--- a/src/main/java/team9502/sinchulgwinong/domain/board/controller/BoardController.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/board/controller/BoardController.java
@@ -96,7 +96,7 @@ public class BoardController {
     }
 
     @DeleteMapping("/{boardId}")
-    public ResponseEntity<GlobalApiResponse<Object>> deleteBoard(
+    public ResponseEntity<GlobalApiResponse<Void>> deleteBoard(
             @PathVariable("boardId") Long boardId,
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
 

--- a/src/main/java/team9502/sinchulgwinong/domain/board/dto/response/BoardResponseDTO.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/board/dto/response/BoardResponseDTO.java
@@ -12,21 +12,27 @@ public class BoardResponseDTO {
 
     private Long userId;
 
+    private String nickName;
+
     private Long boardId;
 
     private String title;
 
     private String content;
 
+    private int commentCount;
+
     private LocalDateTime createdAt;
 
     private LocalDateTime modifiedAt;
 
-    public BoardResponseDTO(Board board) {
+    public BoardResponseDTO(Board board, int commentCount) {
         this.userId = board.getUser().getUserId();
+        this.nickName = board.getUser().getNickname();
         this.boardId = board.getBoardId();
         this.title = board.getBoardTitle();
         this.content = board.getBoardContent();
+        this.commentCount = commentCount;
         this.createdAt = board.getCreatedAt();
         this.modifiedAt = board.getModifiedAt();
     }

--- a/src/main/java/team9502/sinchulgwinong/domain/board/service/BoardService.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/board/service/BoardService.java
@@ -12,6 +12,7 @@ import team9502.sinchulgwinong.domain.board.dto.response.BoardListResponseDTO;
 import team9502.sinchulgwinong.domain.board.dto.response.BoardResponseDTO;
 import team9502.sinchulgwinong.domain.board.entity.Board;
 import team9502.sinchulgwinong.domain.board.repository.BoardRepository;
+import team9502.sinchulgwinong.domain.comment.repository.CommentRepository;
 import team9502.sinchulgwinong.domain.point.enums.SpType;
 import team9502.sinchulgwinong.domain.point.service.PointService;
 import team9502.sinchulgwinong.domain.user.entity.User;
@@ -27,6 +28,7 @@ public class BoardService {
 
     private final BoardRepository boardRepository;
     private final PointService pointService;
+    private final CommentRepository commentRepository;
 
     @Transactional
     public BoardResponseDTO boardCreate(User user, BoardRequestDTO boardRequestDTO) {
@@ -41,9 +43,11 @@ public class BoardService {
 
         boardRepository.save(board);
 
+        int commentCount = commentRepository.countByBoard_BoardId(board.getBoardId());
+
         pointService.earnPoints(user, SpType.BOARD);
 
-        return new BoardResponseDTO(board);
+        return new BoardResponseDTO(board, commentCount);
     }
 
     @Transactional(readOnly = true)
@@ -54,7 +58,10 @@ public class BoardService {
         Page<Board> boardPage = boardRepository.findAll(pageable);
 
         List<BoardResponseDTO> boards = boardPage.stream()
-                .map(BoardResponseDTO::new)
+                .map(board -> {
+                    int commentCount = commentRepository.countByBoard_BoardId(board.getBoardId());
+                    return new BoardResponseDTO(board, commentCount);
+                })
                 .collect(Collectors.toList());
 
         return new BoardListResponseDTO(
@@ -71,7 +78,9 @@ public class BoardService {
         Board board = boardRepository.findById(boardId)
                 .orElseThrow(() -> new ApiException(ErrorCode.BOARD_NOT_FOUND));
 
-        return new BoardResponseDTO(board);
+        int commentCount = commentRepository.countByBoard_BoardId(board.getBoardId());
+
+        return new BoardResponseDTO(board, commentCount);
     }
 
     @Transactional
@@ -93,7 +102,9 @@ public class BoardService {
 
         boardRepository.save(board);
 
-        return new BoardResponseDTO(board);
+        int commentCount = commentRepository.countByBoard_BoardId(board.getBoardId());
+
+        return new BoardResponseDTO(board, commentCount);
     }
 
 
@@ -118,7 +129,10 @@ public class BoardService {
         Page<Board> boardPage = boardRepository.findByUser_UserId(user.getUserId(), pageable);
 
         List<BoardResponseDTO> boardResponseDTOS = boardPage.stream()
-                .map(BoardResponseDTO::new)
+                .map(board -> {
+                    int commentCount = commentRepository.countByBoard_BoardId(board.getBoardId());
+                    return new BoardResponseDTO(board, commentCount);
+                })
                 .toList();
 
         return new BoardListResponseDTO(
@@ -138,7 +152,10 @@ public class BoardService {
                 boardTitle, pageable);
 
         List<BoardResponseDTO> boardResponseDTOS = boardPage.stream()
-                .map(BoardResponseDTO::new)
+                .map(board -> {
+                    int commentCount = commentRepository.countByBoard_BoardId(board.getBoardId());
+                    return new BoardResponseDTO(board, commentCount);
+                })
                 .toList();
 
         return new BoardListResponseDTO(

--- a/src/main/java/team9502/sinchulgwinong/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/comment/repository/CommentRepository.java
@@ -10,4 +10,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     Page<Comment> findByBoard_BoardId(Long boardId, Pageable pageable);
 
     Page<Comment> findByUser_UserId(Long userId, Pageable pageable);
+
+    int countByBoard_BoardId(Long boardId);
 }

--- a/src/main/java/team9502/sinchulgwinong/domain/scrap/repository/BoardScrapsRepository.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/scrap/repository/BoardScrapsRepository.java
@@ -11,5 +11,5 @@ public interface BoardScrapsRepository extends JpaRepository<BoardScrap, Long> {
 
     boolean existsByUser_UserIdAndBoard_BoardId(Long userId, Long boardId);
 
-    BoardScrap findByUser_UserIdAndBoard_BoardId(Long userId, Long boardId);
+    void deleteByUser_UserIdAndBoard_BoardId(Long userId, Long boardId);
 }

--- a/src/main/java/team9502/sinchulgwinong/domain/scrap/repository/CpUserScrapRepository.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/scrap/repository/CpUserScrapRepository.java
@@ -9,7 +9,7 @@ public interface CpUserScrapRepository extends JpaRepository<CpUserScrap, Long> 
 
     boolean existsByCompanyUser_CpUserIdAndUser_UserId(Long cpUserId, Long userId);
 
-    CpUserScrap findByCompanyUser_CpUserIdAndUser_UserId(Long cpUserId, Long userId);
+    void deleteByUser_UserIdAndCompanyUser_CpUserId(Long userId, Long cpUserId);
 
     Page<CpUserScrap> findByUser_UserId(Long userId, Pageable pageable);
 }

--- a/src/main/java/team9502/sinchulgwinong/domain/scrap/repository/JobScrapRepository.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/scrap/repository/JobScrapRepository.java
@@ -9,7 +9,7 @@ public interface JobScrapRepository extends JpaRepository<JobScrap, Long> {
 
     boolean existsByJobBoard_JobBoardIdAndUser_UserId(Long jobBoardId, Long userId);
 
-    JobScrap findByJobBoard_JobBoardIdAndUser_UserId(Long jobBoardId, Long userId);
-
     Page<JobScrap> findByUser_UserId(Long userId, Pageable pageable);
+
+    void deleteByUser_UserIdAndJobBoard_JobBoardId(Long userId, Long jobBoardId);
 }

--- a/src/main/java/team9502/sinchulgwinong/domain/scrap/service/ScrapService.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/scrap/service/ScrapService.java
@@ -10,6 +10,7 @@ import team9502.sinchulgwinong.domain.board.dto.response.BoardListResponseDTO;
 import team9502.sinchulgwinong.domain.board.dto.response.BoardResponseDTO;
 import team9502.sinchulgwinong.domain.board.entity.Board;
 import team9502.sinchulgwinong.domain.board.repository.BoardRepository;
+import team9502.sinchulgwinong.domain.comment.repository.CommentRepository;
 import team9502.sinchulgwinong.domain.companyUser.dto.response.CpUserProfileResponseDTO;
 import team9502.sinchulgwinong.domain.companyUser.entity.CompanyUser;
 import team9502.sinchulgwinong.domain.companyUser.repository.CompanyUserRepository;
@@ -40,6 +41,7 @@ public class ScrapService {
     private final JobScrapRepository jobScrapRepository;
     private final CompanyUserRepository companyUserRepository;
     private final CpUserScrapRepository cpUserScrapRepository;
+    private final CommentRepository commentRepository;
 
     @Transactional
     public boolean scrapCreateBoard(Long boardId, User user) {
@@ -49,10 +51,10 @@ public class ScrapService {
 
         if (boardScrapsRepository.existsByUser_UserIdAndBoard_BoardId(user.getUserId(), boardId)) {
 
-            BoardScrap boardScrap = boardScrapsRepository.findByUser_UserIdAndBoard_BoardId(user.getUserId(), boardId);
+            boardScrapsRepository.deleteByUser_UserIdAndBoard_BoardId(user.getUserId(), boardId);
 
-            boardScrapsRepository.delete(boardScrap);
             return false;
+
         } else {
 
             BoardScrap boardScrap = new BoardScrap();
@@ -75,7 +77,10 @@ public class ScrapService {
         List<BoardResponseDTO> boardResponseDTOS = boardScrapPage.stream()
                 .map(boardScrap -> {
                     Board board = boardScrap.getBoard();
-                    return new BoardResponseDTO(board);
+
+                    int commentCount = commentRepository.countByBoard_BoardId(board.getBoardId());
+
+                    return new BoardResponseDTO(board, commentCount);
                 }).toList();
 
         return new BoardListResponseDTO(
@@ -95,9 +100,7 @@ public class ScrapService {
 
         if (jobScrapRepository.existsByJobBoard_JobBoardIdAndUser_UserId(jobBoardId, user.getUserId())) {
 
-            JobScrap jobScrap = jobScrapRepository.findByJobBoard_JobBoardIdAndUser_UserId(jobBoardId, user.getUserId());
-
-            jobScrapRepository.delete(jobScrap);
+            jobScrapRepository.deleteByUser_UserIdAndJobBoard_JobBoardId(user.getUserId(), jobBoardId);
 
             return false;
 
@@ -145,9 +148,7 @@ public class ScrapService {
 
         if (cpUserScrapRepository.existsByCompanyUser_CpUserIdAndUser_UserId(cpUserId, user.getUserId())) {
 
-            CpUserScrap cpUserScrap = cpUserScrapRepository.findByCompanyUser_CpUserIdAndUser_UserId(cpUserId, user.getUserId());
-
-            cpUserScrapRepository.delete(cpUserScrap);
+            cpUserScrapRepository.deleteByUser_UserIdAndCompanyUser_CpUserId(user.getUserId(), cpUserId);
 
             return false;
 


### PR DESCRIPTION
1. 게시글 전체 조회, 단건 조회, 스크랩 전체 조회시 응답 값에 댓글수를 포함 하도록 수정했습니다.
2. 기업 스크랩시 발생하던 버그를 수정했습니다.
3. 스크랩 삭제 로직에서 불필요한 부분은 지우고 더 간단하게 표현 하도록 수정했습니다.