### PR TITLE
fix: 구인 게시글 응답 값에 기업 이름 포함 하도록 수정

### DIFF
--- a/src/main/java/team9502/sinchulgwinong/domain/jobBoard/dto/response/JobBoardResponseDTO.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/jobBoard/dto/response/JobBoardResponseDTO.java
@@ -18,6 +18,8 @@ public class JobBoardResponseDTO {
 
     private Long cpUserId;
 
+    private String cpName;
+
     private String jobTitle;
 
     private String jobContent;
@@ -45,6 +47,7 @@ public class JobBoardResponseDTO {
     public JobBoardResponseDTO(JobBoard jobBoard) {
         this.jobBoardId = jobBoard.getJobBoardId();
         this.cpUserId = jobBoard.getCompanyUser().getCpUserId();
+        this.cpName = jobBoard.getCompanyUser().getCpName();
         this.jobTitle = jobBoard.getJobTitle();
         this.jobContent = jobBoard.getJobContent();
         this.salaryType = jobBoard.getSalaryType();


### PR DESCRIPTION
1. 구인 게시글 응답 값에 기업 이름 포함 하도록 수정