### PR TITLE
fix: png, jpg, jpge, gif 확장자만 업로드 되도록 구현

### DIFF
--- a/src/main/java/team9502/sinchulgwinong/global/config/WebSecurityConfig.java
+++ b/src/main/java/team9502/sinchulgwinong/global/config/WebSecurityConfig.java
@@ -31,14 +31,26 @@ public class WebSecurityConfig {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/", "/home", "/aws", "/swagger-ui.html", "/v3/api-docs/**", "/swagger-ui/**").permitAll()
-                        .requestMatchers("/auth/signup", "/auth/login", "/auth/cp-signup", "/auth/cp-login").permitAll()
-                        .requestMatchers("/email/**", "/social-login/**").permitAll()
-                        .requestMatchers("/cpUsers/{cpUserId}/profile").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/cpUsers").permitAll()
-                        .requestMatchers("/business/status", "/business/verify").permitAll()
-                        .requestMatchers("/faqs/**").permitAll()
+                        .requestMatchers(
+                                "/",
+                                "/home",
+                                "/aws",
+                                "/v3/api-docs/**",
+                                "/swagger-ui.html",
+                                "/swagger-ui/**",
+                                "/auth/signup",
+                                "/auth/login",
+                                "/auth/cp-signup",
+                                "/auth/cp-login",
+                                "/email/**",
+                                "/social-login/**",
+                                "/cpUsers/{cpUserId}/profile",
+                                "/business/status",
+                                "/business/verify",
+                                "/faqs/**"
+                        ).permitAll()
                         .requestMatchers(HttpMethod.GET,
+                                "/cpUsers",
                                 "/boards",
                                 "/boards/{boardId}",
                                 "/boards/find-boards",

--- a/src/main/java/team9502/sinchulgwinong/global/exception/ErrorCode.java
+++ b/src/main/java/team9502/sinchulgwinong/global/exception/ErrorCode.java
@@ -43,6 +43,7 @@ public enum ErrorCode {
 
     //JobBoard
     JOB_BOARD_ALREADY_AD(HttpStatus.NOT_FOUND, "이미 구인 게시글 광고 중 입니다."),
+    INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST,"지원하지 않는 확장자 입니다."),
 
     // Point
     POINT_NOT_FOUND(HttpStatus.NOT_FOUND, "포인트를 찾을 수 없습니다."),


### PR DESCRIPTION
1. png, jpg, jpge, gif 확장자만 업로드 되도록 로직 추가했습니다.
2. requestMatchers 앤드 포인트 부분 코드를 보기 좋게 정리했습니다.
