### PR TITLE
feature: 업종 대분류,소분류 조회 api, 업종 카테고리 검색으로 구인글 전체 조회하는 api 구현

### DIFF
--- a/src/main/java/team9502/sinchulgwinong/domain/category/controller/JobBoardCategoryController.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/category/controller/JobBoardCategoryController.java
@@ -4,7 +4,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import team9502.sinchulgwinong.domain.category.dto.request.JobBoardCategoryRequestDTO;
+import team9502.sinchulgwinong.domain.category.dto.request.JobCategoryRequestDTO;
+import team9502.sinchulgwinong.domain.category.dto.request.JobLocalityCategoryRequestDTO;
 import team9502.sinchulgwinong.domain.category.service.JobBoardCategoryService;
 import team9502.sinchulgwinong.domain.jobBoard.dto.response.JobBoardListResponseDTO;
 import team9502.sinchulgwinong.global.response.GlobalApiResponse;
@@ -66,12 +67,12 @@ public class JobBoardCategoryController {
 
     @GetMapping("/locality-category")
     public ResponseEntity<GlobalApiResponse<JobBoardListResponseDTO>> getAllLocalityCategory(
-            @RequestBody @Valid JobBoardCategoryRequestDTO jobBoardCategoryRequestDTO,
+            @RequestBody @Valid JobLocalityCategoryRequestDTO jobLocalityCategoryRequestDTO,
             @RequestParam(value = "page", defaultValue = "0") int page,
             @RequestParam(value = "size", defaultValue = "10") int size) {
 
         JobBoardListResponseDTO jobBoardListResponseDTO =
-                jobBoardCategoryService.getAllLocalityCategory(jobBoardCategoryRequestDTO, page, size);
+                jobBoardCategoryService.getAllLocalityCategory(jobLocalityCategoryRequestDTO, page, size);
 
         return ResponseEntity.status(SUCCESS_READ_ALL_CATEGORY_JOB_BOARD.getHttpStatus())
                 .body(
@@ -80,6 +81,48 @@ public class JobBoardCategoryController {
                                 jobBoardListResponseDTO
                         )
                 );
+    }
 
+    @GetMapping("/major-category-name")
+    public ResponseEntity<GlobalApiResponse<Set<String>>> getAllMajorCategoryName(){
+
+        return ResponseEntity.status(SUCCESS_READ_CATEGORY_JOB_BOARD.getHttpStatus())
+                .body(
+                        GlobalApiResponse.of(
+                                SUCCESS_READ_CATEGORY_JOB_BOARD.getMessage(),
+                                jobBoardCategoryService.getAllMajorCategoryName()
+                        )
+                );
+    }
+
+    @GetMapping("/minor-category-name")
+    public ResponseEntity<GlobalApiResponse<Set<String>>> getAllMinorCategoryName(
+            @RequestParam("major-category-name") String majorCategoryName){
+
+        return ResponseEntity.status(SUCCESS_READ_CATEGORY_JOB_BOARD.getHttpStatus())
+                .body(
+                        GlobalApiResponse.of(
+                                SUCCESS_READ_CATEGORY_JOB_BOARD.getMessage(),
+                                jobBoardCategoryService.getAllMinorCategoryName(majorCategoryName)
+                        )
+                );
+    }
+
+    @GetMapping("/job-category")
+    public ResponseEntity<GlobalApiResponse<JobBoardListResponseDTO>> getAllJobCategory(
+            @RequestBody JobCategoryRequestDTO jobCategoryRequestDTO,
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "10") int size){
+
+        JobBoardListResponseDTO jobBoardListResponseDTO =
+                jobBoardCategoryService.getAllJobCategory(jobCategoryRequestDTO, page, size);
+
+        return ResponseEntity.status(SUCCESS_READ_CATEGORY_JOB_BOARD.getHttpStatus())
+                .body(
+                        GlobalApiResponse.of(
+                                SUCCESS_READ_CATEGORY_JOB_BOARD.getMessage(),
+                                jobBoardListResponseDTO
+                        )
+                );
     }
 }

--- a/src/main/java/team9502/sinchulgwinong/domain/category/dto/request/JobCategoryRequestDTO.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/category/dto/request/JobCategoryRequestDTO.java
@@ -1,0 +1,14 @@
+package team9502.sinchulgwinong.domain.category.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class JobCategoryRequestDTO {
+
+    @NotBlank
+    private String majorCategoryName;
+
+    @NotBlank
+    private String minorCategoryName;
+}

--- a/src/main/java/team9502/sinchulgwinong/domain/category/dto/request/JobLocalityCategoryRequestDTO.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/category/dto/request/JobLocalityCategoryRequestDTO.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
-public class JobBoardCategoryRequestDTO {
+public class JobLocalityCategoryRequestDTO {
 
     @NotBlank
     private String regionName;

--- a/src/main/java/team9502/sinchulgwinong/domain/category/entity/JobCategory.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/category/entity/JobCategory.java
@@ -1,0 +1,19 @@
+package team9502.sinchulgwinong.domain.category.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Getter
+@Entity
+public class JobCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long jobCategoryId;
+
+    @Column(nullable = false)
+    private String majorCategoryName;
+
+    @Column(nullable = false)
+    private String minorCategoryName;
+}

--- a/src/main/java/team9502/sinchulgwinong/domain/category/repository/JobCategoryRepository.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/category/repository/JobCategoryRepository.java
@@ -1,0 +1,20 @@
+package team9502.sinchulgwinong.domain.category.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import team9502.sinchulgwinong.domain.category.entity.JobCategory;
+
+import java.util.Set;
+
+public interface JobCategoryRepository extends JpaRepository<JobCategory, Long> {
+
+    @Query("SELECT DISTINCT j.majorCategoryName FROM JobCategory j")
+    Set<String> findMajorCategoryName();
+
+    @Query("SELECT DISTINCT j.minorCategoryName FROM JobCategory j WHERE j.majorCategoryName = :majorCategoryName")
+    Set<String> findMinorCategoryName(@Param("majorCategoryName") String majorCategoryName);
+
+    JobCategory findByMajorCategoryNameAndMinorCategoryName(String majorCategoryName,String minorCategoryName);
+
+}

--- a/src/main/java/team9502/sinchulgwinong/domain/category/service/JobBoardCategoryService.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/category/service/JobBoardCategoryService.java
@@ -6,8 +6,11 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import team9502.sinchulgwinong.domain.category.dto.request.JobBoardCategoryRequestDTO;
+import team9502.sinchulgwinong.domain.category.dto.request.JobCategoryRequestDTO;
+import team9502.sinchulgwinong.domain.category.dto.request.JobLocalityCategoryRequestDTO;
+import team9502.sinchulgwinong.domain.category.entity.JobCategory;
 import team9502.sinchulgwinong.domain.category.entity.Locality;
+import team9502.sinchulgwinong.domain.category.repository.JobCategoryRepository;
 import team9502.sinchulgwinong.domain.category.repository.LocalityRepository;
 import team9502.sinchulgwinong.domain.jobBoard.dto.response.JobBoardListResponseDTO;
 import team9502.sinchulgwinong.domain.jobBoard.dto.response.JobBoardResponseDTO;
@@ -23,6 +26,7 @@ public class JobBoardCategoryService {
 
     private final LocalityRepository localityRepository;
     private final JobBoardRepository jobBoardRepository;
+    private final JobCategoryRepository jobCategoryRepository;
 
     @Transactional(readOnly = true)
     public Set<String> getAllRegionName() {
@@ -44,14 +48,14 @@ public class JobBoardCategoryService {
 
     @Transactional(readOnly = true)
     public JobBoardListResponseDTO getAllLocalityCategory(
-            JobBoardCategoryRequestDTO jobBoardCategoryRequestDTO, int page, int size) {
+            JobLocalityCategoryRequestDTO jobLocalityCategoryRequestDTO, int page, int size) {
 
         Pageable pageable = PageRequest.of(page, size);
 
         Locality locality = localityRepository.findByRegionNameAndSubRegionNameAndLocalityName(
-                jobBoardCategoryRequestDTO.getRegionName(),
-                jobBoardCategoryRequestDTO.getSubRegionName(),
-                jobBoardCategoryRequestDTO.getLocalityName());
+                jobLocalityCategoryRequestDTO.getRegionName(),
+                jobLocalityCategoryRequestDTO.getSubRegionName(),
+                jobLocalityCategoryRequestDTO.getLocalityName());
 
         Page<JobBoard> jobBoardPage = jobBoardRepository.findByLocality_LocalityId(locality.getLocalityId(), pageable);
 
@@ -67,4 +71,41 @@ public class JobBoardCategoryService {
                 jobBoardPage.getSize());
     }
 
+    @Transactional(readOnly = true)
+    public Set<String> getAllMajorCategoryName(){
+
+        return jobCategoryRepository.findMajorCategoryName();
+    }
+
+    @Transactional(readOnly = true)
+    public Set<String> getAllMinorCategoryName(String minorCategoryName){
+
+        return jobCategoryRepository.findMinorCategoryName(minorCategoryName);
+    }
+
+    @Transactional(readOnly = true)
+    public JobBoardListResponseDTO getAllJobCategory(
+            JobCategoryRequestDTO jobCategoryRequestDTO, int page, int size){
+
+        Pageable pageable = PageRequest.of(page, size);
+
+        JobCategory jobCategory =
+                jobCategoryRepository.findByMajorCategoryNameAndMinorCategoryName(
+                        jobCategoryRequestDTO.getMajorCategoryName(),
+                        jobCategoryRequestDTO.getMinorCategoryName());
+
+        Page<JobBoard> jobBoardPage =
+                jobBoardRepository.findByJobCategory_JobCategoryId(jobCategory.getJobCategoryId(), pageable);
+
+        List<JobBoardResponseDTO> jobBoardResponseDTOS = jobBoardPage.stream()
+                .map(JobBoardResponseDTO::new)
+                .toList();
+
+        return new JobBoardListResponseDTO(
+                jobBoardResponseDTOS,
+                jobBoardPage.getTotalElements(),
+                jobBoardPage.getNumber(),
+                jobBoardPage.getTotalPages(),
+                jobBoardPage.getSize());
+    }
 }

--- a/src/main/java/team9502/sinchulgwinong/domain/jobBoard/controller/JobBoardController.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/jobBoard/controller/JobBoardController.java
@@ -82,9 +82,10 @@ public class JobBoardController {
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @PathVariable("jobBoardId") Long jobBoardId,
             @RequestPart(required = false, name = "images") List<MultipartFile> images,
-            @RequestPart(name = "request") @Valid JobBoardUpdateRequestDTO jobBoardUpdateRequestDTO) {
+            @RequestPart(name = "request") JobBoardUpdateRequestDTO jobBoardUpdateRequestDTO) {
 
-        JobBoardResponseDTO jobBoardResponseDTO = jobBoardService.updateJobBoard(userDetails.getCpUserId(), jobBoardId, jobBoardUpdateRequestDTO, images);
+        JobBoardResponseDTO jobBoardResponseDTO = jobBoardService.updateJobBoard(
+                userDetails.getCpUserId(), jobBoardId, jobBoardUpdateRequestDTO, images);
 
         return ResponseEntity.status(SUCCESS_UPDATE_JOB_BOARD.getHttpStatus())
                 .body(

--- a/src/main/java/team9502/sinchulgwinong/domain/jobBoard/dto/request/JobBoardRequestDTO.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/jobBoard/dto/request/JobBoardRequestDTO.java
@@ -1,6 +1,7 @@
 package team9502.sinchulgwinong.domain.jobBoard.dto.request;
 
 import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import team9502.sinchulgwinong.domain.jobBoard.entity.SalaryType;
@@ -10,20 +11,26 @@ import java.time.LocalDate;
 @Getter
 public class JobBoardRequestDTO {
 
-    @NotNull
+    @NotBlank
     private String jobTitle;
 
-    @NotNull
+    @NotBlank
     private String jobContent;
 
-    @NotNull
+    @NotBlank
     private String regionName;
 
-    @NotNull
+    @NotBlank
     private String subRegionName;
 
-    @NotNull
+    @NotBlank
     private String localityName;
+
+    @NotBlank
+    private String majorCategoryName;
+
+    @NotBlank
+    private String minorCategoryName;
 
     @FutureOrPresent
     private LocalDate jobEndDate;
@@ -31,10 +38,10 @@ public class JobBoardRequestDTO {
     @NotNull
     private Integer salaryAmount;
 
-    @NotNull
+    @NotBlank
     private String sex;
 
-    @NotNull
+    @NotBlank
     private String address;
 
     @NotNull

--- a/src/main/java/team9502/sinchulgwinong/domain/jobBoard/dto/request/JobBoardUpdateRequestDTO.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/jobBoard/dto/request/JobBoardUpdateRequestDTO.java
@@ -20,6 +20,10 @@ public class JobBoardUpdateRequestDTO {
 
     private String localityName;
 
+    private String majorCategoryName;
+
+    private String minorCategoryName;
+
     @FutureOrPresent
     private LocalDate jobEndDate;
 

--- a/src/main/java/team9502/sinchulgwinong/domain/jobBoard/dto/response/JobBoardResponseDTO.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/jobBoard/dto/response/JobBoardResponseDTO.java
@@ -20,6 +20,8 @@ public class JobBoardResponseDTO {
 
     private Long localityId;
 
+    private Long jobCategoryId;
+
     private String cpName;
 
     private String jobTitle;
@@ -53,6 +55,11 @@ public class JobBoardResponseDTO {
             this.localityId = jobBoard.getLocality().getLocalityId();
         } else {
             this.localityId = null;
+        }
+        if (jobBoard.getJobCategory() != null) {
+            this.jobCategoryId = jobBoard.getJobCategory().getJobCategoryId();
+        } else {
+            this.jobCategoryId = null;
         }
         this.cpName = jobBoard.getCpName();
         this.jobTitle = jobBoard.getJobTitle();

--- a/src/main/java/team9502/sinchulgwinong/domain/jobBoard/entity/JobBoard.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/jobBoard/entity/JobBoard.java
@@ -3,6 +3,7 @@ package team9502.sinchulgwinong.domain.jobBoard.entity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import team9502.sinchulgwinong.domain.category.entity.JobCategory;
 import team9502.sinchulgwinong.domain.category.entity.Locality;
 import team9502.sinchulgwinong.domain.companyUser.entity.CompanyUser;
 import team9502.sinchulgwinong.global.entity.BaseTimeEntity;
@@ -28,6 +29,11 @@ public class JobBoard extends BaseTimeEntity {
     @OneToOne
     @JoinColumn(name = "localityId")
     private Locality locality;
+
+    @Setter
+    @OneToOne
+    @JoinColumn(name="job_category_id")
+    private JobCategory jobCategory;
 
     @Setter
     @OneToMany(mappedBy = "jobBoard", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/team9502/sinchulgwinong/domain/jobBoard/repository/JobBoardRepository.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/jobBoard/repository/JobBoardRepository.java
@@ -17,4 +17,6 @@ public interface JobBoardRepository extends JpaRepository<JobBoard, Long> {
     boolean existsByCpNameAndJobTitle(String companyName, String jobTitle);
 
     Page<JobBoard> findByLocality_LocalityId(Long localityId, Pageable pageable);
+
+    Page<JobBoard> findByJobCategory_JobCategoryId(Long jobCategoryId, Pageable pageable);
 }

--- a/src/main/java/team9502/sinchulgwinong/domain/jobBoard/service/JobBoardService.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/jobBoard/service/JobBoardService.java
@@ -11,7 +11,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import team9502.sinchulgwinong.domain.category.entity.JobCategory;
 import team9502.sinchulgwinong.domain.category.entity.Locality;
+import team9502.sinchulgwinong.domain.category.repository.JobCategoryRepository;
 import team9502.sinchulgwinong.domain.category.repository.LocalityRepository;
 import team9502.sinchulgwinong.domain.companyUser.entity.CompanyUser;
 import team9502.sinchulgwinong.domain.companyUser.repository.CompanyUserRepository;
@@ -53,6 +55,7 @@ public class JobBoardService {
     private final BoardImageRepository boardImageRepository;
     private final AdJobBoardRepository adJobBoardRepository;
     private final LocalityRepository localityRepository;
+    private final JobCategoryRepository jobCategoryRepository;
     private final PointService pointService;
     private final AmazonS3Client amazonS3Client;
 
@@ -72,10 +75,15 @@ public class JobBoardService {
                 jobBoardRequestDTO.getSubRegionName(),
                 jobBoardRequestDTO.getLocalityName());
 
+        JobCategory jobCategory = jobCategoryRepository.findByMajorCategoryNameAndMinorCategoryName(
+                jobBoardRequestDTO.getMajorCategoryName(),
+                jobBoardRequestDTO.getMinorCategoryName());
+
         JobBoard jobBoard = new JobBoard();
 
         jobBoard.setCompanyUser(companyUser);
         jobBoard.setLocality(locality);
+        jobBoard.setJobCategory(jobCategory);
         jobBoard.setCpName(companyUser.getCpName());
         jobBoard.setJobTitle(jobBoardRequestDTO.getJobTitle());
         jobBoard.setJobContent(jobBoardRequestDTO.getJobContent());
@@ -234,6 +242,15 @@ public class JobBoardService {
                     jobBoardUpdateRequestDTO.getLocalityName());
 
             jobBoard.setLocality(locality);
+        }
+        if (jobBoardUpdateRequestDTO.getMajorCategoryName() != null &&
+                jobBoardUpdateRequestDTO.getMinorCategoryName() != null){
+
+            JobCategory jobCategory = jobCategoryRepository.findByMajorCategoryNameAndMinorCategoryName(
+                    jobBoardUpdateRequestDTO.getMajorCategoryName(),
+                    jobBoardUpdateRequestDTO.getMinorCategoryName());
+
+            jobBoard.setJobCategory(jobCategory);
         }
 
         // 실제로 파일 데이터를 포함하고 있는 파일만 처리

--- a/src/main/java/team9502/sinchulgwinong/domain/jobBoard/service/JobBoardService.java
+++ b/src/main/java/team9502/sinchulgwinong/domain/jobBoard/service/JobBoardService.java
@@ -208,10 +208,10 @@ public class JobBoardService {
             throw new ApiException(ErrorCode.FORBIDDEN_WORK);
         }
 
-        if (jobBoardUpdateRequestDTO.getJobTitle() != null) {
+        if (!jobBoardUpdateRequestDTO.getJobTitle().isEmpty()) {
             jobBoard.setJobTitle(jobBoardUpdateRequestDTO.getJobTitle());
         }
-        if (jobBoardUpdateRequestDTO.getJobContent() != null) {
+        if (!jobBoardUpdateRequestDTO.getJobContent().isEmpty()) {
             jobBoard.setJobContent(jobBoardUpdateRequestDTO.getJobContent());
         }
         if (jobBoardUpdateRequestDTO.getJobEndDate() != null) {
@@ -220,10 +220,10 @@ public class JobBoardService {
         if (jobBoardUpdateRequestDTO.getSalaryAmount() != null) {
             jobBoard.setSalaryAmount(jobBoardUpdateRequestDTO.getSalaryAmount());
         }
-        if (jobBoardUpdateRequestDTO.getSex() != null) {
+        if (!jobBoardUpdateRequestDTO.getSex().isEmpty()) {
             jobBoard.setSex(jobBoardUpdateRequestDTO.getSex());
         }
-        if (jobBoardUpdateRequestDTO.getAddress() != null) {
+        if (!jobBoardUpdateRequestDTO.getAddress().isEmpty()) {
             jobBoard.setAddress(jobBoardUpdateRequestDTO.getAddress());
         }
         if (jobBoardUpdateRequestDTO.getJobStatus() != null) {
@@ -232,9 +232,9 @@ public class JobBoardService {
         if (jobBoardUpdateRequestDTO.getSalaryType() != null) {
             jobBoard.setSalaryType(jobBoardUpdateRequestDTO.getSalaryType());
         }
-        if (jobBoardUpdateRequestDTO.getRegionName() != null &&
-                jobBoardUpdateRequestDTO.getSubRegionName() != null &&
-                jobBoardUpdateRequestDTO.getLocalityName() != null) {
+        if (!jobBoardUpdateRequestDTO.getRegionName().isEmpty() &&
+                !jobBoardUpdateRequestDTO.getSubRegionName().isEmpty() &&
+                !jobBoardUpdateRequestDTO.getLocalityName().isEmpty()) {
 
             Locality locality = localityRepository.findByRegionNameAndSubRegionNameAndLocalityName(
                     jobBoardUpdateRequestDTO.getRegionName(),
@@ -243,8 +243,8 @@ public class JobBoardService {
 
             jobBoard.setLocality(locality);
         }
-        if (jobBoardUpdateRequestDTO.getMajorCategoryName() != null &&
-                jobBoardUpdateRequestDTO.getMinorCategoryName() != null){
+        if (!jobBoardUpdateRequestDTO.getMajorCategoryName().isEmpty() &&
+                !jobBoardUpdateRequestDTO.getMinorCategoryName().isEmpty()) {
 
             JobCategory jobCategory = jobCategoryRepository.findByMajorCategoryNameAndMinorCategoryName(
                     jobBoardUpdateRequestDTO.getMajorCategoryName(),

--- a/src/main/java/team9502/sinchulgwinong/global/config/WebSecurityConfig.java
+++ b/src/main/java/team9502/sinchulgwinong/global/config/WebSecurityConfig.java
@@ -62,6 +62,9 @@ public class WebSecurityConfig {
                                 "/job-boards/sub-region-name",
                                 "/job-boards/locality-name",
                                 "/job-boards/locality-category",
+                                "/job-boards/major-category-name",
+                                "/job-boards/minor-category-name",
+                                "/job-boards/job-category",
                                 "/job-boards/cp-user/{cpUserId}/open-api",
                                 "/job-boards/{jobBoardId}",
                                 "/job-boards/cp-user/{cpUserId}/my-job-boards").permitAll()


### PR DESCRIPTION
1. 업종 대분류,소분류 조회 api, 업종 카테고리 검색으로 구인글 전체 조회하는 api 구현 했습니다.
2. 구인글 생성, 수정시 업종 카테고리도 같이 넣어서 생성 하도록 수정 했습니다.
3. 구인글 응답시 업종 카테고리도 나오도록 수정 했습니다.